### PR TITLE
Put hostname first in hosts_config.json

### DIFF
--- a/irods_config.py
+++ b/irods_config.py
@@ -40,8 +40,8 @@ def configure_hosts_config(docker_client, compose_project):
                 {
                     'address_type': 'local',
                     'addresses': [
-                        {'address': context.container_ip(container)},
                         {'address': context.container_hostname(container)},
+                        {'address': context.container_ip(container)},
                         {'address': alias}
                     ]
                 }


### PR DESCRIPTION
Due to changes in the control plane, the result of running `hostname` on
a given host needs to be the first entry for a given host in
hosts_config.json. This may not be required in the future, but it is for
now.