### PR TITLE
Install which on Centos base image

### DIFF
--- a/projects/centos-7/Dockerfile
+++ b/projects/centos-7/Dockerfile
@@ -2,6 +2,7 @@ FROM centos:7
 
 RUN yum update -y && \
     yum install -y \
+        which \
         epel-release \
         wget \
         python \


### PR DESCRIPTION
The univMSSInterface script used in the iRODS test suite requires this
in order to properly execute the commands therein.

Requires a rebuild of the Centos-based projects for existing users.