### PR TITLE
[30] make errors less confusing [4-2-stable]

### DIFF
--- a/run_plugin_tests.py
+++ b/run_plugin_tests.py
@@ -128,7 +128,10 @@ finally:
     logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory)
 
     if args.extra_logs_path:
-        logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory, logfile_path = args.extra_logs_path)
+        try:
+            logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory, logfile_path = args.extra_logs_path)
+        except docker.errors.NotFound:
+            logging.warning('Path in container not found for --extra-logs-path {!r}'.format(args.extra_logs_path))
 
     if args.cleanup_containers:
         ctx.compose_project.down(include_volumes=True, remove_image_type=False)


### PR DESCRIPTION

When the tests failed and --extra-logs-path was used, there was an
exception reported during the handling of another exception, muddling
the messages reported by` run_plugin_tests.py`.   This condenses the spooling of
errors from the script quite a bit and is more user friendly for that case.