### PR TITLE
[#28] Add unit test runner (main)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -104,6 +104,25 @@ def add_irods_test_args(parser):
                             If indicated, exits on the first test that returns a non-zero exit \
                             code.'''))
 
+    parser.add_argument('--concurrent-test-executor-count',
+                        dest='executor_count', type=int, default=1,
+                        help=textwrap.dedent('''\
+                            Number of concurrent exeecutors to run tests at the same time.'''))
+
+    parser.add_argument('--discard-logs',
+                        dest='save_logs', default=True, action='store_false',
+                        help=textwrap.dedent('''\
+                            Indicates that the logs should not be collected from the \
+                            containers.'''))
+
+    parser.add_argument('--leak-containers',
+                        action='store_false', dest='cleanup_containers',
+                        help='If indicated, the containers will not be torn down.')
+
+    parser.add_argument('--skip-setup',
+                        action='store_false', dest='do_setup',
+                        help='If indicated, the iRODS servers will not be set up.')
+
 
 def add_database_config_args(parser):
     '''Add argparse options related to setting up and configuring iRODS.

--- a/irods_testing_environment/context.py
+++ b/irods_testing_environment/context.py
@@ -119,6 +119,17 @@ def service_account_irods_env():
     return os.path.join(irods_home(), '.irods', 'irods_environment.json')
 
 
+def run_tests_script():
+    """Return the path to the script which runs the python tests."""
+    import os
+    return os.path.join(irods_home(), 'scripts', 'run_tests.py')
+
+
+def python():
+    """Return the appropriate python interpreter."""
+    return 'python3'
+
+
 def sanitize(repo_or_tag):
     """Sanitize the input from special characters rejected by docker-compose.
 

--- a/irods_testing_environment/context.py
+++ b/irods_testing_environment/context.py
@@ -130,6 +130,12 @@ def python():
     return 'python3'
 
 
+def unit_tests():
+    """Return the path to the directory containing packaged unit tests."""
+    import os
+    return os.path.join(irods_home(), 'unit_tests')
+
+
 def sanitize(repo_or_tag):
     """Sanitize the input from special characters rejected by docker-compose.
 

--- a/irods_testing_environment/test_manager.py
+++ b/irods_testing_environment/test_manager.py
@@ -1,0 +1,104 @@
+# grown-up modules
+import logging
+
+# local modules
+from . import test_runner
+
+class test_manager:
+    """A class that manages a list of tests and `test_runners` for executing tests."""
+
+    def __init__(self, containers, tests, test_type='irods_python_suite'):
+        """Constructor for `test_manager`.
+
+        Arguments:
+        containers -- list of containers which will be used to construct `test_runner`s
+        tests -- list of tests which will run on the `test_runners`
+        test_type -- a string representing the name of the class implementing the test_runner
+        """
+        tr_name = '_'.join(['test_runner', test_type])
+        tr = eval('.'.join(['test_runner', tr_name]))
+        logging.info('[{}]'.format(tr))
+        self.test_runners = [tr(c) for c in containers]
+
+        logging.info('[{}]'.format(tests))
+        logging.info('[{}]'.format(str(self)))
+        logging.info('[{}]'.format(self.test_runners))
+
+        for i, t in enumerate(tests):
+            index = i % len(self.test_runners)
+
+            logging.info('index [{}], test [{}]'.format(index, t))
+            self.test_runners[index].add_test(t)
+
+        logging.info('[{}]'.format(str(self)))
+
+
+    def __str__(self):
+        """Return a string representation of the list of `test_runners`."""
+        return str([str(tr) for tr in self.test_runners])
+
+
+    def failed_tests(self):
+        """Return a list of failed tests across the managed `test_runners`."""
+        return [t for tr in self.test_runners for t in tr.failed_tests()]
+
+
+    def return_code(self):
+        """Return int representing the 'overall' return code from a test run.
+
+        Return 0 if all `test_runners` have a return code of 0. Otherwise, 1.
+        """
+        logging.info('[{}]'.format([tr.rc for tr in self.test_runners]))
+        return 0 if [tr.rc for tr in self.test_runners].count(0) == len(self.test_runners) else 1
+
+
+    def result_string(self):
+        """Return string showing tests that passed and failed from each `test_runner.`"""
+        r = '==== begin test run results ====\n'
+        for tr in self.test_runners:
+            r = r + tr.result_string()
+
+        if self.return_code() is not 0:
+            r = r + 'List of failed tests:\n\t{}\n'.format(' '.join(self.failed_tests()))
+            r = r + 'Return code:[{}]\n'.format(self.return_code())
+
+        else:
+            r = r + 'All tests passed! :)\n'
+
+        r = r + '==== end of test run results ====\n'
+
+        return r
+
+
+    def run(self, fail_fast=True, *args):
+        """Run managed `test_runners` in parallel.
+
+        Arguments:
+        fail_fast -- if True, the first test to fail ends the run
+        *args -- arguments to be passed along to the `test_runner`'s specific `run` method
+        """
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures_to_test_runners = {
+                executor.submit(tr.run, fail_fast, *args): tr for tr in self.test_runners
+            }
+
+            for f in concurrent.futures.as_completed(futures_to_test_runners):
+                tr = futures_to_test_runners[f]
+
+                try:
+                    f.result()
+
+                    if tr.rc is 0 and len(tr.failed_tests()) is 0:
+                        logging.warning('tests completed successfully [{}]'.format(tr.name()))
+                    else:
+                        logging.warning('some tests failed [{}]'.format(tr.name()))
+
+                except Exception as e:
+                    logging.warning('[{}]: exception raised while running test'.format(tr.name()))
+                    logging.warning(e)
+
+                    tr.rc = 1
+
+                    if fail_fast: raise

--- a/irods_testing_environment/test_runner.py
+++ b/irods_testing_environment/test_runner.py
@@ -143,3 +143,19 @@ class test_runner_irods_python_suite(test_runner):
                                             user='irods',
                                             workdir=context.irods_home(),
                                             stream_output=True)
+
+
+class test_runner_irods_unit_tests(test_runner):
+    def __init__(self, executing_container, tests=None):
+        super(test_runner_irods_unit_tests, self).__init__(executing_container, tests)
+
+
+    def execute_test(self, test):
+        """Execute `test` and return the command run and the return code."""
+        import os
+        cmd = [os.path.join(context.unit_tests(), test)]
+        return cmd, execute.execute_command(self.executor,
+                                            ' '.join(cmd),
+                                            user='irods',
+                                            workdir=context.irods_home(),
+                                            stream_output=True)

--- a/irods_testing_environment/test_runner.py
+++ b/irods_testing_environment/test_runner.py
@@ -1,0 +1,145 @@
+# grown-up modules
+import logging
+
+# local modules
+from . import context
+from . import execute
+
+class test_runner:
+    """A class that manages a list of tests and can execute them on a managed container."""
+
+    def __init__(self, executing_container, tests=None):
+        """Constructor for `test_runner`.
+
+        The list of tests is not required to be initialized here. `add_test` will append a
+        test to the end of the test list.
+
+        Arguments:
+        executing_container -- the container on which tests will be executed
+        tests -- optional list of tests to use with this runner
+        """
+        # TODO: each test runner is tied to a single container... might need to abstract this out later
+        self.executor = executing_container
+        self.tests = tests or list()
+        self.passed = list()
+        self.failed = list()
+        self.rc = 0
+
+
+    def __str__(self):
+        """Return a string representation of a map representing the data members."""
+        return str({
+            'executing_container': self.name(),
+            'return_code': self.rc,
+            'test_list': self.tests,
+            'passed_tests': self.passed_tests(),
+            'failed_tests': self.failed_tests()
+        })
+
+
+    def add_test(self, test):
+        """Append `test` to the test list and return self."""
+        logging.info('before [{}]'.format(self))
+        self.tests.append(test)
+        logging.info('after  [{}]'.format(self))
+        return self
+
+
+    def name(self):
+        """Return the name of the executing container."""
+        return self.executor.name
+
+
+    def test_list(self):
+        """Return the list of tests for which this runner is responsible."""
+        return self.tests
+
+
+    def passed_tests(self):
+        """Return the list of tests which have been executed and passed."""
+        return self.passed
+
+
+    def failed_tests(self):
+        """Return the list of tests which have been executed and failed."""
+        return self.failed
+
+
+    def skipped_tests(self):
+        """Return the list of tests which have not been executed."""
+        executed_tests = self.passed_tests() + self.failed_tests()
+        return list(filter(lambda t: t not in executed_tests, self.test_list()))
+
+
+    def result_string(self):
+        """Return a string representing the results of running the test list."""
+        r = '-----\nresults for [{}]\n'.format(self.name())
+
+        r = r + '\tpassed tests:\n'
+        for t in self.passed_tests():
+            r = r + '\t\t[{}]\n'.format(t)
+
+        r = r + '\tskipped tests:\n'
+        for t in self.skipped_tests():
+            r = r + '\t\t[{}]\n'.format(t)
+
+        r = r + '\tfailed tests:\n'
+        for t in self.failed_tests():
+            r = r + '\t\t[{}]\n'.format(t)
+
+        r = r + '\treturn code:[{}]\n-----\n'.format(self.rc)
+
+        return r
+
+
+    def run(self, fail_fast=True, *args):
+        """Execute test list sequentially on executing container.
+
+        Arguments:
+        fail_fast -- if True, the first test to fail ends the run
+        *args -- any additional arguments that the test execution can take
+        """
+        for t in self.tests:
+            cmd, ec = self.execute_test(t, *args)
+
+            if ec is 0:
+                self.passed_tests().append(t)
+                logging.info('[{}]: cmd succeeded [{}]'.format(self.name(), cmd))
+
+            else:
+                self.rc = ec
+                self.failed_tests().append(t)
+                logging.warning('[{}]: cmd failed [{}] [{}]'.format(self.name(), ec, cmd))
+
+                if fail_fast:
+                    raise RuntimeError('[{}]: command failed [{}]'.format(self.name(), cmd))
+
+        if self.rc is not 0:
+            logging.error('[{}]: tests that failed [{}]'.format(self.name(), self.failed_tests()))
+
+
+    def execute_test(self, test, *args):
+        """Execute `test` with return the command run and the return code."""
+        raise NotImplementedError('test_runner is a base class and should not be used directly')
+
+
+class test_runner_irods_python_suite(test_runner):
+    def __init__(self, executing_container, tests=None):
+        super(test_runner_irods_python_suite, self).__init__(executing_container, tests)
+
+
+    @staticmethod
+    def run_tests_command():
+        """Return a list of strings used as a space-delimited invocation of the test runner."""
+        return [context.python(), context.run_tests_script()]
+
+
+    def execute_test(self, test, options=None):
+        """Execute `test` with `options` and return the command run and the return code."""
+        cmd = self.run_tests_command() + ['--run_specific_test', test]
+        if options: cmd.append(options)
+        return cmd, execute.execute_command(self.executor,
+                                            ' '.join(cmd),
+                                            user='irods',
+                                            workdir=context.irods_home(),
+                                            stream_output=True)

--- a/irods_testing_environment/test_utils.py
+++ b/irods_testing_environment/test_utils.py
@@ -47,6 +47,28 @@ def make_output_directory(dirname, basename):
 
     return directory
 
+def run_unit_tests(containers, test_list=None, fail_fast=True):
+    """Run a set of tests from the python test suite for iRODS.
+
+    Arguments:
+    containers -- target containers on which the tests will run
+    test_list -- a list of strings of the tests to be run
+    options -- list of strings representing script options to pass to the run_tests.py script
+    fail_fast -- if True, stop running after first failure; else, runs all tests
+    """
+    tests = test_list or get_unit_test_list(containers[0])
+
+    tm = test_manager.test_manager(containers, tests, test_type='irods_unit_tests')
+
+    try:
+        tm.run(fail_fast)
+
+    finally:
+        logging.error(tm.result_string())
+
+    return tm.return_code()
+
+
 def run_specific_tests(containers, test_list=None, options=None, fail_fast=True):
     """Run a set of tests from the python test suite for iRODS.
 
@@ -67,6 +89,7 @@ def run_specific_tests(containers, test_list=None, options=None, fail_fast=True)
         logging.error(tm.result_string())
 
     return tm.return_code()
+
 
 def run_python_test_suite(container, options=None):
     """Run the entire python test suite for iRODS.
@@ -146,6 +169,20 @@ def run_test_hook_file_in_container(container, path_to_test_hook, options=None):
                         .format(ec, command, container.name))
 
     return ec
+
+
+def get_unit_test_list(container):
+    """Return list of unit tests extracted from unit_tests_list.json file in `container`.
+
+    Arguments:
+    container -- target container from which test list will be extracted
+    """
+    from . import json_utils
+    return json_utils.get_json_from_file(container,
+                                         os.path.join(
+                                             context.unit_tests(),
+                                             'unit_tests_list.json')
+                                         )
 
 
 def get_test_list(container):

--- a/irods_testing_environment/test_utils.py
+++ b/irods_testing_environment/test_utils.py
@@ -8,11 +8,8 @@ from . import archive
 from . import context
 from . import execute
 from . import services
+from . import test_manager
 from .install import install
-
-def path_to_run_tests_script():
-    """Return the path to the script which runs the tests."""
-    return os.path.join(context.irods_home(), 'scripts', 'run_tests.py')
 
 def job_name(project_name, prefix=None):
     """Construct unique job name based on the docker-compose project name.
@@ -50,118 +47,26 @@ def make_output_directory(dirname, basename):
 
     return directory
 
-
-def run_specific_tests(containers, tests, options=None, fail_fast=True):
+def run_specific_tests(containers, test_list=None, options=None, fail_fast=True):
     """Run a set of tests from the python test suite for iRODS.
 
     Arguments:
     containers -- target containers on which the tests will run
-    tests -- a list of strings of the tests to be run
+    test_list -- a list of strings of the tests to be run
     options -- list of strings representing script options to pass to the run_tests.py script
     fail_fast -- if True, stop running after first failure; else, runs all tests
     """
-    import concurrent.futures
+    tests = test_list or get_test_list(containers[0])
 
-    def run_specific_test(options, tests, container, fail_fast):
-        command = ['python3', path_to_run_tests_script()]
+    tm = test_manager.test_manager(containers, tests)
 
-        if options: command.extend(options)
+    try:
+        tm.run(fail_fast, options)
 
-        rc = 0
-        failed_tests = list()
+    finally:
+        logging.error(tm.result_string())
 
-        for test in tests:
-            cmd = command + ['--run_specific_test', test]
-            ec = execute.execute_command(container,
-                                         ' '.join(cmd),
-                                         user='irods',
-                                         workdir=context.irods_home(),
-                                         stream_output=True)
-
-            if ec is not 0:
-                rc = ec
-                failed_tests.append(test)
-                last_command_to_fail = cmd
-                logging.warning('[{}]: command exited with error code [{}] [{}] [{}]'
-                                .format(container.name, ec, cmd, container.name))
-
-                if fail_fast:
-                    logging.critical('[{}]: command failed [{}]'.format(container.name, cmd))
-                    break
-
-        if rc is not 0:
-            logging.error('[{}]: last command to fail [{}]'.format(container.name, last_command_to_fail))
-            logging.error('[{}]: tests that failed [{}]'.format(container.name, failed_tests))
-
-        return (rc, failed_tests)
-
-    test_lists = {
-        c.name: {
-            'tests': list(),
-            'rc': 0,
-            'failures': list()
-        }
-        for c in containers
-    }
-    keys = list(test_lists.keys())
-
-    logging.info('keys [{}], tests [{}]'.format(keys, tests))
-
-    # Evenly distribute the tests amongst the containers. The -1 is to avoid going beyond the
-    # end of the list of keys since it is 0-indexed.
-    i = 0
-    for t in tests:
-        logging.debug('test_lists [{}]'.format(test_lists))
-        logging.debug('index [{}], test [{}]'.format(i % len(keys), t))
-        test_lists[keys[i % len(keys)]]['tests'].append(t)
-        i = i + 1
-
-    logging.info('test_lists [{}]'.format(test_lists))
-
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        futures_to_containers = {
-            executor.submit(
-                run_specific_test,
-                options, test_lists[c.name]['tests'], c, fail_fast
-            ): c for c in containers
-        }
-
-        for f in concurrent.futures.as_completed(futures_to_containers):
-            container = futures_to_containers[f]
-
-            try:
-                rc, failed_tests = f.result()
-                if rc is 0 and len(failed_tests) is 0:
-                    logging.warning('tests completed successfully [{}]'.format(container.name))
-                else:
-                    logging.warning('some tests failed [{}]'.format(container.name))
-
-                test_lists[container.name]['rc'] = rc
-                test_lists[container.name]['failures'] = failed_tests
-
-            except Exception as e:
-                logging.error('exception raised while running iRODS tests [{}]'
-                              .format(container.name))
-                logging.error(e)
-
-                test_lists[container.name]['rc'] = 1
-
-    rc = 0
-    for c in containers:
-        # TODO: it's not really an error, I just want to make sure it gets shown
-        logging.error('-----\nresults for [{}]'.format(c.name))
-        logging.error('\ttests run:')
-        for t in test_lists[c.name]['tests']:
-            logging.error('\t\t[{}]'.format(t))
-        logging.error('\tfailed tests:')
-        for f in test_lists[c.name]['failures']:
-            logging.error('\t\t[{}]'.format(f))
-        ec = test_lists[c.name]['rc']
-        if ec is not 0:
-            rc = ec
-        logging.error('\treturn code:[{}]\n-----\n'.format(ec))
-
-    return rc
+    return tm.return_code()
 
 def run_python_test_suite(container, options=None):
     """Run the entire python test suite for iRODS.
@@ -170,7 +75,7 @@ def run_python_test_suite(container, options=None):
     container -- target container on which the test script will run
     options -- list of strings representing script options to pass to the run_tests.py script
     """
-    command = ['python3', path_to_run_tests_script(), '--run_python_suite']
+    command = ['python3', context.run_tests_script(), '--run_python_suite']
 
     if options: command.extend(options)
 
@@ -216,6 +121,7 @@ def run_test_hook_file(container, path_to_test_hook_on_host, options=None):
     f = os.path.abspath(path_to_test_hook_on_host)
     archive.copy_archive_to_container(container, archive.create_archive([f]))
     return run_test_hook_file_in_container(container, f, options)
+
 
 def run_test_hook_file_in_container(container, path_to_test_hook, options=None):
     """Run the test hook at the specified path in the container.

--- a/run_core_tests.py
+++ b/run_core_tests.py
@@ -95,16 +95,9 @@ if __name__ == "__main__":
             ssl.configure_ssl_in_zone(ctx.docker_client, ctx.compose_project)
             options.append('--use_ssl')
 
-        if args.tests:
-            tests = list(args.tests)
-
-        else:
-            tests = list(test_utils.get_test_list(containers[0]))
-
-
         start_time = time.time()
 
-        rc = test_utils.run_specific_tests(containers, tests, options, args.fail_fast)
+        rc = test_utils.run_specific_tests(containers, args.tests, options, args.fail_fast)
 
         end_time = time.time()
 

--- a/run_federation_tests.py
+++ b/run_federation_tests.py
@@ -65,37 +65,39 @@ if __name__ == "__main__":
     containers = list()
 
     try:
-        # Bring up the services
-        logging.debug('bringing up project [{}]'.format(ctx.compose_project.name))
-        containers = ctx.compose_project.up(scale_override={
-            context.irods_catalog_database_service(): 2,
-            context.irods_catalog_provider_service(): 2,
-            context.irods_catalog_consumer_service(): 0
-        })
+        if args.do_setup:
+            # Bring up the services
+            logging.debug('bringing up project [{}]'.format(ctx.compose_project.name))
+            containers = ctx.compose_project.up(scale_override={
+                context.irods_catalog_database_service(): 2,
+                context.irods_catalog_provider_service(): 2,
+                context.irods_catalog_consumer_service(): 0
+            })
 
         # The catalog consumers are only determined after the containers are running
         zone_info_list = federate.get_info_for_zones(ctx, ['tempZone', 'otherZone'])
 
-        install.install_irods_packages(ctx,
-                                       externals_directory=args.irods_externals_package_directory,
-                                       package_directory=args.package_directory,
-                                       package_version=args.package_version)
+        if args.do_setup:
+            install.install_irods_packages(ctx,
+                                           externals_directory=args.irods_externals_package_directory,
+                                           package_directory=args.package_directory,
+                                           package_version=args.package_version)
 
-        for z in zone_info_list:
-            irods_setup.setup_irods_zone(ctx,
-                                         provider_service_instance=z.provider_service_instance,
-                                         database_service_instance=z.database_service_instance,
-                                         consumer_service_instances=z.consumer_service_instances,
-                                         odbc_driver=args.odbc_driver,
-                                         zone_name=z.zone_name,
-                                         zone_key=z.zone_key,
-                                         negotiation_key=z.negotiation_key)
+            for z in zone_info_list:
+                irods_setup.setup_irods_zone(ctx,
+                                             provider_service_instance=z.provider_service_instance,
+                                             database_service_instance=z.database_service_instance,
+                                             consumer_service_instances=z.consumer_service_instances,
+                                             odbc_driver=args.odbc_driver,
+                                             zone_name=z.zone_name,
+                                             zone_key=z.zone_key,
+                                             negotiation_key=z.negotiation_key)
 
-        federate.form_federation_clique(ctx, zone_info_list)
+            federate.form_federation_clique(ctx, zone_info_list)
 
-        # Configure the containers for running iRODS automated tests
-        logging.info('configuring iRODS containers for testing')
-        irods_config.configure_irods_testing(ctx.docker_client, ctx.compose_project)
+            # Configure the containers for running iRODS automated tests
+            logging.info('configuring iRODS containers for testing')
+            irods_config.configure_irods_testing(ctx.docker_client, ctx.compose_project)
 
         # Get the container on which the command is to be executed
         container = ctx.docker_client.containers.get(
@@ -107,7 +109,7 @@ if __name__ == "__main__":
 
         options = list()
 
-        #if args.use_ssl:
+        #if args.do_setup and args.use_ssl:
             #ssl.configure_ssl_in_zone(ctx.docker_client, ctx.compose_project)
             #options.append('--use_ssl')
 
@@ -128,7 +130,7 @@ if __name__ == "__main__":
         execute.execute_command(container, 'iadmin lu', user='irods')
         execute.execute_command(container, 'iadmin lz', user='irods')
 
-        rc = test_utils.run_specific_tests(container,
+        rc = test_utils.run_specific_tests([container],
                                            args.tests or ['test_federation'],
                                            options,
                                            args.fail_fast)

--- a/run_plugin_tests.py
+++ b/run_plugin_tests.py
@@ -27,14 +27,6 @@ cli.add_irods_package_args(parser)
 cli.add_irods_test_args(parser)
 cli.add_irods_plugin_args(parser)
 
-parser.add_argument('--skip-setup',
-                    action='store_false', dest='do_setup',
-                    help='If indicated, the iRODS servers will not be set up.')
-
-parser.add_argument('--leak-containers',
-                    action='store_false', dest='cleanup_containers',
-                    help='If indicated, the containers will not be torn down.')
-
 parser.add_argument('--test-hook-path',
                     metavar='PATH_TO_TEST_HOOK_FILE',
                     dest='test_hook',

--- a/run_topology_tests.py
+++ b/run_topology_tests.py
@@ -71,19 +71,20 @@ if __name__ == "__main__":
     last_command_to_fail = None
 
     try:
-        # Bring up the services
-        logging.debug('bringing up project [{}]'.format(ctx.compose_project.name))
-        consumer_count = 3
-        services.create_topology(ctx,
-                                 externals_directory=args.irods_externals_package_directory,
-                                 package_directory=args.package_directory,
-                                 package_version=args.package_version,
-                                 odbc_driver=args.odbc_driver,
-                                 consumer_count=consumer_count)
+        if args.do_setup:
+            # Bring up the services
+            logging.debug('bringing up project [{}]'.format(ctx.compose_project.name))
+            consumer_count = 3
+            services.create_topology(ctx,
+                                     externals_directory=args.irods_externals_package_directory,
+                                     package_directory=args.package_directory,
+                                     package_version=args.package_version,
+                                     odbc_driver=args.odbc_driver,
+                                     consumer_count=consumer_count)
 
-        # Configure the containers for running iRODS automated tests
-        logging.info('configuring iRODS containers for testing')
-        irods_config.configure_irods_testing(ctx.docker_client, ctx.compose_project)
+            # Configure the containers for running iRODS automated tests
+            logging.info('configuring iRODS containers for testing')
+            irods_config.configure_irods_testing(ctx.docker_client, ctx.compose_project)
 
         run_on_consumer = args.run_on == 'consumer'
 
@@ -115,12 +116,12 @@ if __name__ == "__main__":
 
         options.extend(['--hostnames', icat_hostname, hostname_1, hostname_2, hostname_3])
 
-        if args.use_ssl:
+        if args.do_setup and args.use_ssl:
             ssl.configure_ssl_in_zone(ctx.docker_client, ctx.compose_project)
             options.append('--use_ssl')
 
         if args.tests:
-            rc = test_utils.run_specific_tests(container,
+            rc = test_utils.run_specific_tests([container],
                                                list(args.tests),
                                                options,
                                                args.fail_fast)

--- a/run_unit_tests.py
+++ b/run_unit_tests.py
@@ -1,0 +1,104 @@
+# grown-up modules
+import compose.cli.command
+import docker
+import logging
+import os
+
+# local modules
+from irods_testing_environment import archive
+from irods_testing_environment import context
+from irods_testing_environment import irods_config
+from irods_testing_environment import services
+from irods_testing_environment import test_utils
+
+if __name__ == "__main__":
+    import argparse
+    import textwrap
+    import time
+
+    import cli
+    from irods_testing_environment import logs
+
+    parser = argparse.ArgumentParser(description='Run iRODS tests in a consistent environment.')
+
+    cli.add_common_args(parser)
+    cli.add_compose_args(parser)
+    cli.add_database_config_args(parser)
+    cli.add_irods_package_args(parser)
+    cli.add_irods_test_args(parser)
+
+    args = parser.parse_args()
+
+    if args.package_directory and args.package_version:
+        print('--package-directory and --package-version are incompatible')
+        exit(1)
+
+    project_directory = os.path.abspath(args.project_directory or os.getcwd())
+
+    ctx = context.context(docker.from_env(),
+                          compose.cli.command.get_project(
+                              project_dir=project_directory,
+                              project_name=args.project_name))
+
+    if args.output_directory:
+        dirname = args.output_directory
+    else:
+        import tempfile
+        dirname = tempfile.mkdtemp(prefix=ctx.compose_project.name)
+
+    job_name = test_utils.job_name(ctx.compose_project.name, args.job_name)
+
+    output_directory = test_utils.make_output_directory(dirname, job_name)
+
+    logs.configure(args.verbosity, os.path.join(output_directory, 'script_output.log'))
+
+    rc = 0
+    last_command_to_fail = None
+
+    try:
+        if args.do_setup:
+            # Bring up the services
+            logging.debug('bringing up project [{}]'.format(ctx.compose_project.name))
+            consumer_count = 0
+            services.create_topologies(ctx,
+                                       zone_count=args.executor_count,
+                                       externals_directory=args.irods_externals_package_directory,
+                                       package_directory=args.package_directory,
+                                       package_version=args.package_version,
+                                       odbc_driver=args.odbc_driver,
+                                       consumer_count=consumer_count)
+
+            # Configure the containers for running iRODS automated tests
+            logging.info('configuring iRODS containers for testing')
+            irods_config.configure_irods_testing(ctx.docker_client, ctx.compose_project)
+
+        # Get the container on which the command is to be executed
+        containers = [
+            ctx.docker_client.containers.get(
+                context.container_name(ctx.compose_project.name,
+                                       context.irods_catalog_provider_service(),
+                                       service_instance=i + 1)
+                )
+            for i in range(args.executor_count)
+        ]
+
+        start_time = time.time()
+
+        rc = test_utils.run_unit_tests(containers, args.tests, args.fail_fast)
+
+        end_time = time.time()
+
+        logging.error('tests completed; time [{}] seconds, success [{}]'.format(end_time - start_time, rc is 0))
+
+    except Exception as e:
+        logging.critical(e)
+
+        raise
+
+    finally:
+        logging.warning('collecting logs [{}]'.format(output_directory))
+        logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory)
+
+        ctx.compose_project.down(include_volumes=True, remove_image_type=False)
+
+    exit(rc)


### PR DESCRIPTION
Depends on the unit tests getting packaged with `irods-server` and installed in `$IRODS_HOME/unit_tests` (see irods/irods#6164)

Encapsulated the test running context into a `test_manager` which has a collection of `test_runners` to which it distributes to-be-executed tests.