### PR TITLE
Add parallel support to plugin test runner

### DIFF
--- a/irods_testing_environment/container_info.py
+++ b/irods_testing_environment/container_info.py
@@ -1,0 +1,7 @@
+def python(container):
+    """Return command to run python appropriately per detected iRODS version in `container`."""
+    from . import irods_config
+
+    major, minor, patch = irods_config.get_irods_version(container)
+
+    return 'python' if minor < 3 else 'python3'

--- a/irods_testing_environment/install/install.py
+++ b/irods_testing_environment/install/install.py
@@ -277,15 +277,16 @@ def install_pip_package_from_repo(container,
     repo_name -- name of the git repository to clone
     branch -- branch to checkout in cloned git repository
     """
+    from .. import container_info
     from .. import services
-    from .. import test_utils
 
     repo_path = services.clone_repository_to_container(container,
                                                        repo_name,
                                                        url_base=url_base,
                                                        branch=branch)
-
-    ec = execute.execute_command(container, '{} -m pip install -e {}'.format(test_utils.python(container), repo_path))
+    ec = execute.execute_command(container, ' '.join(
+                                 [container_info.python(container),
+                                  '-m', 'pip', 'install', repo_path]))
     if ec is not 0:
         raise RuntimeError('Failed to install pip package [{}] [{}]'
                            .format(repo_path, container.name))

--- a/irods_testing_environment/install/install.py
+++ b/irods_testing_environment/install/install.py
@@ -4,6 +4,7 @@ import os
 
 # local modules
 from .. import archive
+from .. import container_info
 from .. import context
 from .. import execute
 
@@ -277,7 +278,6 @@ def install_pip_package_from_repo(container,
     repo_name -- name of the git repository to clone
     branch -- branch to checkout in cloned git repository
     """
-    from .. import container_info
     from .. import services
 
     repo_path = services.clone_repository_to_container(container,

--- a/irods_testing_environment/irods_setup.py
+++ b/irods_testing_environment/irods_setup.py
@@ -286,7 +286,7 @@ def setup_irods_server(container, setup_input):
     container -- docker.client.container on which the iRODS packages are installed
     setup_input -- string which will be provided as input to the iRODS setup script
     """
-    from . import test_utils
+    from . import container_info
     irodsctl = os.path.join(context.irods_home(), 'irodsctl')
     ec = execute.execute_command(container, '{} stop'.format(irodsctl), user='irods')
     if ec is not 0:
@@ -299,7 +299,8 @@ def setup_irods_server(container, setup_input):
     execute.execute_command(container, 'cat /input')
 
     path_to_setup_script = os.path.join(context.irods_home(), 'scripts', 'setup_irods.py')
-    run_setup_script = 'bash -c \'{} {} < /input\''.format(test_utils.python(container), path_to_setup_script)
+    run_setup_script = 'bash -c \'{} {} < /input\''.format(container_info.python(container),
+                                                           path_to_setup_script)
     ec = execute.execute_command(container, run_setup_script)
     if ec is not 0:
         raise RuntimeError('failed to set up iRODS server [{}]'.format(container.name))

--- a/irods_testing_environment/services.py
+++ b/irods_testing_environment/services.py
@@ -112,4 +112,3 @@ def clone_repository_to_container(container,
                                             [os.path.abspath(repo_path)], repo_name))
 
     return repo_path
-

--- a/irods_testing_environment/test_manager.py
+++ b/irods_testing_environment/test_manager.py
@@ -71,7 +71,7 @@ class test_manager:
         if self.duration > 0:
             hours = int(self.duration / 60 / 60)
             minutes = self.duration / 60 - hours * 60
-            r = r + 'time elapsed: [{:9.4}]seconds ([{:4}]hours [{:7.4}]minutes)\n'.format(
+            r = r + 'time elapsed: [{:>9.4f}]seconds ([{:>4d}]hours [{:>7.4f}]minutes)\n'.format(
                     self.duration, hours, minutes)
 
         r = r + '==== end of test run results ====\n'

--- a/irods_testing_environment/test_runner.py
+++ b/irods_testing_environment/test_runner.py
@@ -86,8 +86,7 @@ class test_runner:
 
         r = r + '\tpassed tests:\n'
         for test, duration in self.passed_tests().items():
-            duration_str = '{:9.4}'.format(duration)
-            r = r + '\t\t[[{:9}]s]\t[{}]\n'.format(duration_str, test)
+            r = r + '\t\t[[{:>9.4f}]s]\t[{}]\n'.format(duration, test)
 
         r = r + '\tskipped tests:\n'
         for t in self.skipped_tests():
@@ -95,8 +94,7 @@ class test_runner:
 
         r = r + '\tfailed tests:\n'
         for test, duration in self.failed_tests().items():
-            duration_str = '{:9.4}'.format(duration)
-            r = r + '\t\t[[{:9}]s]\t[{}]\n'.format(duration_str, test)
+            r = r + '\t\t[[{:>9.4f}]s]\t[{}]\n'.format(duration, test)
 
         r = r + '\treturn code:[{}]\n'.format(self.rc)
 

--- a/irods_testing_environment/test_runner.py
+++ b/irods_testing_environment/test_runner.py
@@ -161,8 +161,8 @@ class test_runner_irods_python_suite(test_runner):
     @staticmethod
     def run_tests_command(container):
         """Return a list of strings used as a space-delimited invocation of the test runner."""
-        from . import test_utils
-        return [test_utils.python(container), context.run_tests_script()]
+        from . import container_info
+        return [container_info.python(container), context.run_tests_script()]
 
 
     def execute_test(self, test, options=None):

--- a/irods_testing_environment/test_utils.py
+++ b/irods_testing_environment/test_utils.py
@@ -10,7 +10,6 @@ from . import context
 from . import execute
 from . import services
 from . import test_manager
-from .install import install
 
 def job_name(project_name, prefix=None):
     """Construct unique job name based on the docker-compose project name.
@@ -70,6 +69,39 @@ def run_unit_tests(containers, test_list=None, fail_fast=True):
     return tm.return_code()
 
 
+def run_plugin_tests(containers,
+                     plugin_name,
+                     path_to_test_hook_on_host=None,
+                     test_list=None,
+                     options=None,
+                     fail_fast=True):
+    """Run a set of tests from the test hook for the specified iRODS plugin.
+
+    Arguments:
+    containers -- target containers on which the tests will run
+    plugin_name -- name of the git repo hosting the plugin test hook
+    path_to_test_hook_on_host -- local filesystem path on host machine to test hook
+    test_list -- a list of strings of the tests to be run
+    options -- list of strings representing script options to pass to the run_tests.py script
+    fail_fast -- if True, stop running after first failure; else, runs all tests
+    """
+    tests = test_list or [f'test_{plugin_name}']
+
+    tm = test_manager.test_manager(containers, tests, test_type='irods_plugin_tests')
+
+    try:
+        tm.run(fail_fast,
+               plugin_repo_name=plugin_name,
+               plugin_branch=None,
+               path_to_test_hook_on_host=path_to_test_hook_on_host,
+               options=options)
+
+    finally:
+        logging.error(tm.result_string())
+
+    return tm.return_code()
+
+
 def run_specific_tests(containers, test_list=None, options=None, fail_fast=True):
     """Run a set of tests from the python test suite for iRODS.
 
@@ -109,62 +141,6 @@ def run_python_test_suite(container, options=None):
                                  ' '.join(command),
                                  user='irods',
                                  workdir=context.irods_home(),
-                                 stream_output=True)
-
-    if ec is not 0:
-        logging.warning('command exited with error code [{}] [{}] [{}]'
-                        .format(ec, command, container.name))
-
-    return ec
-
-
-def run_test_hook(container, repo_name, branch=None, options=None):
-    """Run the test hook from the specified git repository.
-
-    Arguments:
-    container -- target container on which the test script will run
-    repo_name -- name of the git repo
-    branch -- name of the branch to checkout in cloned git repo
-    options -- list of strings representing script options to pass to the run_tests.py script
-    """
-    repo_path = services.clone_repository_to_container(container, repo_name, branch=branch)
-
-    # TODO: option?
-    path_to_test_hook = os.path.join(repo_path,
-                                     'irods_consortium_continuous_integration_test_hook.py')
-
-    return run_test_hook_file_in_container(container, path_to_test_hook, options)
-
-
-def run_test_hook_file(container, path_to_test_hook_on_host, options=None):
-    """Run the local test hook in the container.
-
-    Arguments:
-    container -- target container on which the test hook will run
-    path_to_test_hook_on_host -- local filesystem path on host machine to test hook
-    options -- list of strings representing script options to pass to the run_tests.py script
-    """
-    f = os.path.abspath(path_to_test_hook_on_host)
-    archive.copy_archive_to_container(container, archive.create_archive([f]))
-    return run_test_hook_file_in_container(container, f, options)
-
-
-def run_test_hook_file_in_container(container, path_to_test_hook, options=None):
-    """Run the test hook at the specified path in the container.
-
-    Arguments:
-    container -- target container on which the test script will run
-    path_to_test_hook -- path in the container for the test hook file
-    options -- list of strings representing script options to pass to the run_tests.py script
-    """
-    install.install_pip_package_from_repo(container, 'irods_python_ci_utilities')
-
-    command = [container_info.python(container), path_to_test_hook]
-
-    if options: command.extend(options)
-
-    ec = execute.execute_command(container,
-                                 ' '.join(command),
                                  stream_output=True)
 
     if ec is not 0:

--- a/irods_testing_environment/test_utils.py
+++ b/irods_testing_environment/test_utils.py
@@ -5,6 +5,7 @@ import tempfile
 
 # local modules
 from . import archive
+from . import container_info
 from . import context
 from . import execute
 from . import services
@@ -98,7 +99,9 @@ def run_python_test_suite(container, options=None):
     container -- target container on which the test script will run
     options -- list of strings representing script options to pass to the run_tests.py script
     """
-    command = [python(container), context.run_tests_script(), '--run_python_suite']
+    command = [container_info.python(container),
+               context.run_tests_script(),
+               '--run_python_suite']
 
     if options: command.extend(options)
 
@@ -156,7 +159,7 @@ def run_test_hook_file_in_container(container, path_to_test_hook, options=None):
     """
     install.install_pip_package_from_repo(container, 'irods_python_ci_utilities')
 
-    command = ['python3', path_to_test_hook]
+    command = [container_info.python(container), path_to_test_hook]
 
     if options: command.extend(options)
 
@@ -198,12 +201,3 @@ def get_test_list(container):
                                              'scripts',
                                              'core_tests_list.json')
                                          )
-
-
-def python(container):
-    """Return command to run python appropriately per detected iRODS version in `container`."""
-    from . import irods_config
-
-    major, minor, patch = irods_config.get_irods_version(container)
-
-    return 'python' if minor < 3 else 'python3'

--- a/projects/centos-7/Dockerfile
+++ b/projects/centos-7/Dockerfile
@@ -3,26 +3,50 @@ FROM centos:7
 RUN \
   yum update -y && \
   yum install -y \
-    which \
+    authd \
     epel-release \
-    wget \
     gcc-c++ \
+    gnupg \
     make \
+    python \
+    python-pip \
     python3 \
     python3-pip \
     rsyslog \
-    gnupg \
+    sudo \
     unixODBC-devel \
-    authd
-  #&& \
-  #yum clean all && \
-  #rm -rf /var/cache/yum /tmp/* && \
+    wget \
+    which \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
 
-RUN yum install -y python3-devel
+# python 2 and 3 must be installed separately because yum will ignore/discard python2
+RUN \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
+  yum install -y \
+    python3 \
+    python3-devel \
+    python3-pip \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
 
 RUN pip3 install xmlrunner distro psutil pyodbc jsonschema requests
 
-RUN pip install xmlrunner psutil pyodbc jsonschema requests
+RUN \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
+  yum install -y \
+    python \
+    python-devel \
+    python-distro \
+    python-pip \
+    python-requests \
+    python-jsonschema \
+    python-psutil \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
 
 RUN rpm --import https://packages.irods.org/irods-signing-key.asc && \
     wget -qO - https://packages.irods.org/renci-irods.yum.repo | tee /etc/yum.repos.d/renci-irods.yum.repo

--- a/run_core_tests.py
+++ b/run_core_tests.py
@@ -103,16 +103,25 @@ if __name__ == "__main__":
 
     finally:
         if args.save_logs:
-            logging.warning('collecting logs [{}]'.format(output_directory))
+            try:
+                logging.warning('collecting logs [{}]'.format(output_directory))
 
-            # collect the usual logs
-            logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory)
+                # collect the usual logs
+                logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory)
 
-            # and then the test reports
-            archive.collect_files_from_containers(ctx.docker_client,
-                                                  ctx.irods_containers(),
-                                                  [os.path.join(context.irods_home(), 'test-reports')],
-                                                  output_directory)
+                # and then the test reports
+                archive.collect_files_from_containers(ctx.docker_client,
+                                                      ctx.irods_containers(),
+                                                      [os.path.join(context.irods_home(), 'test-reports')],
+                                                      output_directory)
+
+            except Exception as e:
+                logging.error(e)
+                logging.error('failed to collect some log files')
+
+                if rc is 0:
+                    rc = 1
+
 
         if args.cleanup_containers:
             ctx.compose_project.down(include_volumes=True, remove_image_type=False)

--- a/run_core_tests.py
+++ b/run_core_tests.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
                 logging.error(e)
                 logging.error('failed to collect some log files')
 
-                if rc is 0:
+                if rc == 0:
                     rc = 1
 
 

--- a/run_plugin_tests.py
+++ b/run_plugin_tests.py
@@ -117,14 +117,15 @@ except Exception as e:
     raise
 
 finally:
-    logging.warning('collecting logs [{}]'.format(output_directory))
-    logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory)
+    if args.save_logs:
+        logging.warning('collecting logs [{}]'.format(output_directory))
+        logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory)
 
-    if args.extra_logs_path:
-        try:
-            logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory, logfile_path = args.extra_logs_path)
-        except docker.errors.NotFound:
-            logging.warning('Path in container not found for --extra-logs-path {!r}'.format(args.extra_logs_path))
+        if args.extra_logs_path:
+            try:
+                logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory, logfile_path = args.extra_logs_path)
+            except docker.errors.NotFound:
+                logging.warning('Path in container not found for --extra-logs-path {!r}'.format(args.extra_logs_path))
 
     if args.cleanup_containers:
         ctx.compose_project.down(include_volumes=True, remove_image_type=False)

--- a/run_plugin_tests.py
+++ b/run_plugin_tests.py
@@ -10,11 +10,9 @@ import textwrap
 from irods_testing_environment import archive
 from irods_testing_environment import context
 from irods_testing_environment import irods_config
-from irods_testing_environment import irods_setup
 from irods_testing_environment import logs
-from irods_testing_environment import ssl_setup
+from irods_testing_environment import services
 from irods_testing_environment import test_utils
-from irods_testing_environment.install import install
 
 import cli
 
@@ -62,54 +60,50 @@ output_directory = test_utils.make_output_directory(dirname, job_name)
 logs.configure(args.verbosity, os.path.join(output_directory, 'script_output.log'))
 
 rc = 0
-last_command_to_fail = None
+
 try:
     if args.do_setup:
         # Bring up the services
-        logging.debug('bringing up project [{}]'.format(ctx.compose_project.name))
         consumer_count = 0
-        # TODO: may need to extend container privileges to allow for mungefs, etc.
-        ctx.compose_project.build()
-        containers = ctx.compose_project.up(scale_override={
-            context.irods_catalog_consumer_service(): consumer_count
-        })
-
-        install.make_installer(ctx.platform_name()).install_irods_packages(
-            ctx,
-            externals_directory=args.irods_externals_package_directory,
-            package_directory=args.package_directory,
-            package_version=args.package_version)
-
-        irods_setup.setup_irods_zone(ctx, odbc_driver=args.odbc_driver)
+        services.create_topologies(ctx,
+                                   zone_count=args.executor_count,
+                                   externals_directory=args.irods_externals_package_directory,
+                                   package_directory=args.package_directory,
+                                   package_version=args.package_version,
+                                   odbc_driver=args.odbc_driver,
+                                   consumer_count=consumer_count)
 
         # Configure the containers for running iRODS automated tests
         logging.info('configuring iRODS containers for testing')
         irods_config.configure_irods_testing(ctx.docker_client, ctx.compose_project)
 
     # Get the container on which the command is to be executed
-    container = ctx.docker_client.containers.get(
-        context.container_name(ctx.compose_project.name,
-                               context.irods_catalog_provider_service(),
-                               service_instance=1)
-    )
+    containers = [
+        ctx.docker_client.containers.get(
+            context.container_name(ctx.compose_project.name,
+                                   context.irods_catalog_provider_service(),
+                                   service_instance=i + 1)
+            )
+        for i in range(args.executor_count)
+    ]
+    logging.debug('got containers to run on [{}]'.format(container.name for container in containers))
 
     plugin_package_directory = os.path.abspath(args.plugin_package_directory)
 
-    archive.copy_archive_to_container(container,
-                                      archive.create_archive(
+    for c in containers:
+        archive.copy_archive_to_container(c,
+                                          archive.create_archive(
                                           [plugin_package_directory],
                                           args.plugin_name))
 
-    options = ['--output_root_directory', output_directory,
-               '--built_packages_root_directory', plugin_package_directory]
+    options = ['--built_packages_root_directory', plugin_package_directory]
 
-    if args.test_hook:
-        rc = test_utils.run_test_hook_file(container, args.test_hook, options)
-    else:
-        rc = test_utils.run_test_hook(container,
-                                      args.plugin_name,
-                                      branch='4-2-stable',
-                                      options=options)
+    rc = test_utils.run_plugin_tests(containers,
+                                     args.plugin_name,
+                                     args.test_hook,
+                                     args.tests,
+                                     options,
+                                     args.fail_fast)
 
 except Exception as e:
     logging.critical(e)
@@ -118,16 +112,33 @@ except Exception as e:
 
 finally:
     if args.save_logs:
-        logging.warning('collecting logs [{}]'.format(output_directory))
-        logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory)
+        try:
+            logging.warning('collecting logs [{}]'.format(output_directory))
 
-        if args.extra_logs_path:
-            try:
-                logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory, logfile_path = args.extra_logs_path)
-            except docker.errors.NotFound:
-                logging.warning('Path in container not found for --extra-logs-path {!r}'.format(args.extra_logs_path))
+            # collect the usual logs
+            logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory)
+
+            # and then the test reports
+            archive.collect_files_from_containers(ctx.docker_client,
+                                                  ctx.irods_containers(),
+                                                  [os.path.join(context.irods_home(), 'test-reports')],
+                                                  output_directory)
+
+        except Exception as e:
+            logging.error(e)
+            logging.error('failed to collect some log files')
+
+            if rc == 0:
+                rc = 1
+
+    if args.extra_logs_path:
+        try:
+            logs.collect_logs(ctx.docker_client, ctx.irods_containers(), output_directory, logfile_path = args.extra_logs_path)
+        except docker.errors.NotFound:
+            logging.warning('Path in container not found for --extra-logs-path {!r}'.format(args.extra_logs_path))
 
     if args.cleanup_containers:
         ctx.compose_project.down(include_volumes=True, remove_image_type=False)
+
 
 exit(rc)


### PR DESCRIPTION
Requires that test hooks have a `--skip-setup` and `--test` option so that we don't install the packages and stand up services repeatedly and so that test cases can be distributed among concurrent test executors.