### PR TITLE
Allow for empty tests list with plugin runner and running the same test repeatedly

### DIFF
--- a/irods_testing_environment/test_manager.py
+++ b/irods_testing_environment/test_manager.py
@@ -70,12 +70,17 @@ class test_manager:
     def result_string(self):
         """Return string showing tests that passed and failed from each `test_runner.`"""
         r = '==== begin test run results ====\n'
+        tests_were_skipped = False
         for tr in self.test_runners:
             r = r + tr.result_string()
+            tests_were_skipped = tests_were_skipped if tests_were_skipped else len(tr.skipped_tests()) > 0
 
         if self.return_code() is not 0:
-            r = r + 'List of failed tests:\n\t{}\n'.format(' '.join([t or 'all tests' for t in self.failed_tests()]))
+            r = r + 'List of failed tests:\n\t{}\n'.format(' '.join([t or 'all tests' for t,_ in self.failed_tests()]))
             r = r + 'Return code:[{}]\n'.format(self.return_code())
+
+        elif tests_were_skipped:
+            r = r + 'Some tests were skipped or did not complete...\n'
 
         else:
             r = r + 'All tests passed! :)\n'

--- a/irods_testing_environment/test_utils.py
+++ b/irods_testing_environment/test_utils.py
@@ -85,9 +85,7 @@ def run_plugin_tests(containers,
     options -- list of strings representing script options to pass to the run_tests.py script
     fail_fast -- if True, stop running after first failure; else, runs all tests
     """
-    tests = test_list or [f'test_{plugin_name}']
-
-    tm = test_manager.test_manager(containers, tests, test_type='irods_plugin_tests')
+    tm = test_manager.test_manager(containers, test_list, test_type='irods_plugin_tests')
 
     try:
         tm.run(fail_fast,


### PR DESCRIPTION
Still trying this out, but this will allow for plugin test hooks to fall back to the "default" behavior should no `--tests` option be used with the `run_plugin_tests.py` script.