### PR TITLE
[#49] Add MySQL support for new platforms

### DIFF
--- a/irods_testing_environment/odbc_setup.py
+++ b/irods_testing_environment/odbc_setup.py
@@ -200,20 +200,6 @@ def configure_odbc_driver_ubuntu_1804_mysql_57(csp_container, odbc_driver):
     configure_mysql_odbc_driver(csp_container, os.path.abspath(odbc_driver))
 
 
-def configure_odbc_driver_ubuntu_2004_mysql_8029(csp_container, odbc_driver):
-    """Configure ODBC driver for mysql 8.0 on ubuntu 20.04.
-
-    Argument:
-    csp_container -- docker container on which the iRODS catalog service provider is running
-    odbc_driver -- path to local archive file containing the ODBC driver package
-    """
-    if not odbc_driver:
-        odbc_driver = download_mysql_odbc_driver(
-            'https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc-8.0.29-linux-glibc2.12-x86-64bit.tar.gz')
-
-    configure_mysql_odbc_driver(csp_container, os.path.abspath(odbc_driver))
-
-
 def configure_odbc_driver_centos_7_mysql_57(csp_container, odbc_driver):
     """Configure ODBC driver for mysql 5.7 on centos 7.
 
@@ -228,22 +214,6 @@ def configure_odbc_driver_centos_7_mysql_57(csp_container, odbc_driver):
     configure_mysql_odbc_driver(csp_container, os.path.abspath(odbc_driver))
 
 
-# TODO: no .tar.gz available for debian 11...
-def configure_odbc_driver_debian_11_mysql_57(csp_container, odbc_driver):
-    """Configure ODBC driver for mysql 5.7 on debian 11.
-
-    Argument:
-    csp_container -- docker container on which the iRODS catalog service provider is running
-    odbc_driver -- path to local archive file containing the ODBC driver package
-    """
-    if not odbc_driver:
-        odbc_driver = download_mysql_odbc_driver(
-            'https://downloads.mysql.com/archives/get/p/10/file/mysql-connector-odbc_8.0.27-1debian11_amd64.deb')
-
-    configure_mysql_odbc_driver(csp_container, os.path.abspath(odbc_driver))
-
-
-# TODO: no .tar.gz available for RHEL 8...
 def configure_odbc_driver_almalinux_8_mysql_57(csp_container, odbc_driver):
     """Configure ODBC driver for mysql 5.7 on almalinux 8.
 
@@ -253,7 +223,63 @@ def configure_odbc_driver_almalinux_8_mysql_57(csp_container, odbc_driver):
     """
     if not odbc_driver:
         odbc_driver = download_mysql_odbc_driver(
-            'https://downloads.mysql.com/archives/get/p/10/file/mysql-connector-odbc-5.3.13-linux-el7-x86-64bit.tar.gz')
+            'https://downloads.mysql.com/archives/get/p/10/file/mysql-connector-odbc-5.3.13-linux-glibc2.12-x86-64bit.tar.gz')
+
+    configure_mysql_odbc_driver(csp_container, os.path.abspath(odbc_driver))
+
+
+def configure_odbc_driver_debian_11_mysql_57(csp_container, odbc_driver):
+    """Configure ODBC driver for mysql 5.7 on debian 11.
+
+    Argument:
+    csp_container -- docker container on which the iRODS catalog service provider is running
+    odbc_driver -- path to local archive file containing the ODBC driver package
+    """
+    if not odbc_driver:
+        odbc_driver = download_mysql_odbc_driver(
+            'https://downloads.mysql.com/archives/get/p/10/file/mysql-connector-odbc-5.3.13-linux-glibc2.12-x86-64bit.tar.gz')
+
+    configure_mysql_odbc_driver(csp_container, os.path.abspath(odbc_driver))
+
+
+def configure_odbc_driver_ubuntu_2004_mysql_8029(csp_container, odbc_driver):
+    """Configure ODBC driver for mysql 8.0 on ubuntu 20.04.
+
+    Argument:
+    csp_container -- docker container on which the iRODS catalog service provider is running
+    odbc_driver -- path to local archive file containing the ODBC driver package
+    """
+    if not odbc_driver:
+        odbc_driver = download_mysql_odbc_driver(
+            'https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc-8.0.29-linux-glibc2.12-x86-64bit.tar.gz')
+
+    configure_mysql_odbc_driver(csp_container, os.path.abspath(odbc_driver))
+
+
+def configure_odbc_driver_debian_11_mysql_8029(csp_container, odbc_driver):
+    """Configure ODBC driver for mysql 8.0 on debian 11.
+
+    Argument:
+    csp_container -- docker container on which the iRODS catalog service provider is running
+    odbc_driver -- path to local archive file containing the ODBC driver package
+    """
+    if not odbc_driver:
+        odbc_driver = download_mysql_odbc_driver(
+            'https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc-8.0.29-linux-glibc2.12-x86-64bit.tar.gz')
+
+    configure_mysql_odbc_driver(csp_container, os.path.abspath(odbc_driver))
+
+
+def configure_odbc_driver_almalinux_8_mysql_8029(csp_container, odbc_driver):
+    """Configure ODBC driver for mysql 8.0 on almalinux 8.
+
+    Argument:
+    csp_container -- docker container on which the iRODS catalog service provider is running
+    odbc_driver -- path to local archive file containing the ODBC driver package
+    """
+    if not odbc_driver:
+        odbc_driver = download_mysql_odbc_driver(
+            'https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc-8.0.29-linux-glibc2.12-x86-64bit.tar.gz')
 
     configure_mysql_odbc_driver(csp_container, os.path.abspath(odbc_driver))
 

--- a/projects/almalinux-8/almalinux-8-mysql-8/docker-compose.yml
+++ b/projects/almalinux-8/almalinux-8-mysql-8/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3'
+
+services:
+  catalog:
+    image: mysql:8.0.29
+    environment:
+      - MYSQL_ROOT_PASSWORD=testpassword
+      - MYSQL_USER=irods
+      - MYSQL_PASSWORD=testpassword
+
+    # MySQL 8.0 defaults to using UTF-8 (utf8mb4/utf8mb4_0900_ai_ci). iRODS requires that queries
+    # be case-sensitive. Therefore, we set the --collation-server option to one that satisfies that
+    # requirement.
+    #
+    # --disable-log-bin is needed so that setup succeeds. Without this option, the following
+    # error is produced and setup fails:
+    #
+    #    ERROR 1418 (HY000): This function has none of DETERMINISTIC, NO SQL,
+    #    or READS SQL DATA in its declaration and binary logging is enabled
+    #    (you *might* want to use the less safe log_bin_trust_function_creators
+    #    variable)
+    #
+    command: "--transaction-isolation=READ-COMMITTED --collation-server=utf8mb4_0900_as_cs --disable-log-bin"
+
+    # The default docker security profile restricts several things to protect the OS. This results
+    # in the MySQL container logging the following on each interaction:
+    #
+    #    mbind: Operation not permitted
+    #
+    # This does not have any known impact on testing, but if you feel it does, consider uncommenting
+    # the "cap_add" section below. Doing so will resolve the mbind message and may resolve other
+    # problems.
+    #
+    # For more information about this, see the following:
+    #
+    #    https://github.com/docker-library/mysql/issues/303
+    #
+    #cap_add:
+    #    - SYS_NICE
+
+  irods-catalog-provider:
+    build:
+      context: ..
+    depends_on:
+      - catalog
+
+  irods-catalog-consumer:
+    build:
+      context: ..
+    depends_on:
+      - irods-catalog-provider
+

--- a/projects/debian-11/debian-11-mysql-8/docker-compose.yml
+++ b/projects/debian-11/debian-11-mysql-8/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3'
+
+services:
+  catalog:
+    image: mysql:8.0.29
+    environment:
+      - MYSQL_ROOT_PASSWORD=testpassword
+      - MYSQL_USER=irods
+      - MYSQL_PASSWORD=testpassword
+
+    # MySQL 8.0 defaults to using UTF-8 (utf8mb4/utf8mb4_0900_ai_ci). iRODS requires that queries
+    # be case-sensitive. Therefore, we set the --collation-server option to one that satisfies that
+    # requirement.
+    #
+    # --disable-log-bin is needed so that setup succeeds. Without this option, the following
+    # error is produced and setup fails:
+    #
+    #    ERROR 1418 (HY000): This function has none of DETERMINISTIC, NO SQL,
+    #    or READS SQL DATA in its declaration and binary logging is enabled
+    #    (you *might* want to use the less safe log_bin_trust_function_creators
+    #    variable)
+    #
+    command: "--transaction-isolation=READ-COMMITTED --collation-server=utf8mb4_0900_as_cs --disable-log-bin"
+
+    # The default docker security profile restricts several things to protect the OS. This results
+    # in the MySQL container logging the following on each interaction:
+    #
+    #    mbind: Operation not permitted
+    #
+    # This does not have any known impact on testing, but if you feel it does, consider uncommenting
+    # the "cap_add" section below. Doing so will resolve the mbind message and may resolve other
+    # problems.
+    #
+    # For more information about this, see the following:
+    #
+    #    https://github.com/docker-library/mysql/issues/303
+    #
+    #cap_add:
+    #    - SYS_NICE
+
+  irods-catalog-provider:
+    build:
+      context: ..
+    depends_on:
+      - catalog
+
+  irods-catalog-consumer:
+    build:
+      context: ..
+    depends_on:
+      - irods-catalog-provider
+


### PR DESCRIPTION
Adapted from changes in fd736731fb5f3a23c1409305b96a6e3087d307a8

Added MySQL 5.7 and 8.0 support for debian:11 and almalinux:8.

---

I've only confirmed MySQL 8.0 on debian:11, to be honest. I suspect @korydraughn has a branch with MySQL 5.7 for almalinux:8, so maybe he will have a better take on this.