### PR TITLE
enable powertools for running plugin tests on almalinux

### DIFF
--- a/projects/almalinux-8/Dockerfile
+++ b/projects/almalinux-8/Dockerfile
@@ -46,6 +46,9 @@ RUN yum update -y && \
 
 RUN python3 -m pip install unittest-xml-reporting distro psutil pyodbc jsonschema requests
 
+RUN yum install -y dnf-plugins-core
+RUN yum config-manager --set-enabled powertools
+
 COPY rsyslog.conf /etc/rsyslog.conf
 
 RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir

--- a/projects/almalinux-8/Dockerfile
+++ b/projects/almalinux-8/Dockerfile
@@ -6,7 +6,9 @@ RUN yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && 
         epel-release \
         gnupg \
         wget \
+        dnf-plugins-core \
     && \
+    yum config-manager --set-enabled powertools && \
     yum clean all && \
     rm -rf /var/cache/yum /tmp/*
 
@@ -45,9 +47,6 @@ RUN yum update -y && \
     rm -rf /var/cache/yum /tmp/*
 
 RUN python3 -m pip install unittest-xml-reporting distro psutil pyodbc jsonschema requests
-
-RUN yum install -y dnf-plugins-core
-RUN yum config-manager --set-enabled powertools
 
 COPY rsyslog.conf /etc/rsyslog.conf
 


### PR DESCRIPTION
https://github.com/irods/irods_netcdf/issues/25 is related but this requirement may apply in a broader way whenever a plugin depends on system libraries (ie build and runtime prerequisites other than irods-externals)