### PR TITLE
[irods/irods#4421] Added ability to mount a common volume

### DIFF
--- a/projects/almalinux-8/Dockerfile
+++ b/projects/almalinux-8/Dockerfile
@@ -55,4 +55,6 @@ RUN rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
 
 COPY rsyslog.conf /etc/rsyslog.conf
 
+RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir
+
 ENTRYPOINT ["bash", "-c", "until false; do sleep 2147483647d; done"]

--- a/projects/almalinux-8/almalinux-8-mysql-5.7/docker-compose.yml
+++ b/projects/almalinux-8/almalinux-8-mysql-5.7/docker-compose.yml
@@ -22,10 +22,18 @@ services:
       context: ..
     depends_on:
       - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
   irods-catalog-consumer:
     build:
       context: ..
     depends_on:
       - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:

--- a/projects/almalinux-8/almalinux-8-mysql-8/docker-compose.yml
+++ b/projects/almalinux-8/almalinux-8-mysql-8/docker-compose.yml
@@ -43,10 +43,19 @@ services:
       context: ..
     depends_on:
       - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
   irods-catalog-consumer:
     build:
       context: ..
     depends_on:
       - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:
 

--- a/projects/almalinux-8/almalinux-8-postgres-10.12/docker-compose.yml
+++ b/projects/almalinux-8/almalinux-8-postgres-10.12/docker-compose.yml
@@ -11,10 +11,19 @@ services:
       context: ..
     depends_on:
       - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
   irods-catalog-consumer:
     build:
       context: ..
     depends_on:
       - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:
 

--- a/projects/centos-7/Dockerfile
+++ b/projects/centos-7/Dockerfile
@@ -56,4 +56,6 @@ RUN rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
 
 COPY rsyslog.conf /etc/rsyslog.conf
 
+RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir
+
 ENTRYPOINT ["bash", "-c", "until false; do sleep 2147483647d; done"]

--- a/projects/centos-7/centos-7-mysql-5.7/docker-compose.yml
+++ b/projects/centos-7/centos-7-mysql-5.7/docker-compose.yml
@@ -22,10 +22,19 @@ services:
       context: ..
     depends_on:
       - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
   irods-catalog-consumer:
     build:
       context: ..
     depends_on:
       - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:
 

--- a/projects/centos-7/centos-7-postgres-10.12/docker-compose.yml
+++ b/projects/centos-7/centos-7-postgres-10.12/docker-compose.yml
@@ -11,10 +11,18 @@ services:
       context: ..
     depends_on:
       - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
   irods-catalog-consumer:
     build:
       context: ..
     depends_on:
       - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:

--- a/projects/debian-11/Dockerfile
+++ b/projects/debian-11/Dockerfile
@@ -34,4 +34,6 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - 
 RUN wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://core-dev.irods.org/apt/ bullseye main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
 
+RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir
+
 ENTRYPOINT ["bash", "-c", "until false; do sleep 2147483647d; done"]

--- a/projects/debian-11/debian-11-mysql-5.7/docker-compose.yml
+++ b/projects/debian-11/debian-11-mysql-5.7/docker-compose.yml
@@ -22,10 +22,18 @@ services:
       context: ..
     depends_on:
       - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
   irods-catalog-consumer:
     build:
       context: ..
     depends_on:
       - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:

--- a/projects/debian-11/debian-11-mysql-8/docker-compose.yml
+++ b/projects/debian-11/debian-11-mysql-8/docker-compose.yml
@@ -43,10 +43,19 @@ services:
       context: ..
     depends_on:
       - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
   irods-catalog-consumer:
     build:
       context: ..
     depends_on:
       - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:
 

--- a/projects/debian-11/debian-11-postgres-10.12/docker-compose.yml
+++ b/projects/debian-11/debian-11-postgres-10.12/docker-compose.yml
@@ -11,9 +11,18 @@ services:
             context: ..
         depends_on:
             - catalog
+        volumes:
+            - shared_volume:/irods_testing_environment_mount_dir
 
     irods-catalog-consumer:
         build:
             context: ..
         depends_on:
             - irods-catalog-provider
+        volumes:
+            - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:

--- a/projects/ubuntu-18.04/Dockerfile
+++ b/projects/ubuntu-18.04/Dockerfile
@@ -40,4 +40,6 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - 
 RUN wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://core-dev.irods.org/apt/ bionic main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
 
+RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir
+
 ENTRYPOINT ["bash", "-c", "until false; do sleep 2147483647d; done"]

--- a/projects/ubuntu-18.04/ubuntu-18.04-mysql-5.7/docker-compose.yml
+++ b/projects/ubuntu-18.04/ubuntu-18.04-mysql-5.7/docker-compose.yml
@@ -22,10 +22,19 @@ services:
       context: ..
     depends_on:
       - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
   irods-catalog-consumer:
     build:
       context: ..
     depends_on:
       - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:
 

--- a/projects/ubuntu-18.04/ubuntu-18.04-postgres-10.12/docker-compose.yml
+++ b/projects/ubuntu-18.04/ubuntu-18.04-postgres-10.12/docker-compose.yml
@@ -11,9 +11,18 @@ services:
             context: ..
         depends_on:
             - catalog
+        volumes:
+            - shared_volume:/irods_testing_environment_mount_dir
 
     irods-catalog-consumer:
         build:
             context: ..
         depends_on:
             - irods-catalog-provider
+        volumes:
+            - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:

--- a/projects/ubuntu-20.04/Dockerfile
+++ b/projects/ubuntu-20.04/Dockerfile
@@ -33,4 +33,6 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - 
 RUN wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://core-dev.irods.org/apt/ focal main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
 
+RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir
+
 ENTRYPOINT ["bash", "-c", "until false; do sleep 2147483647d; done"]

--- a/projects/ubuntu-20.04/ubuntu-20.04-mysql-5.7/docker-compose.yml
+++ b/projects/ubuntu-20.04/ubuntu-20.04-mysql-5.7/docker-compose.yml
@@ -22,10 +22,19 @@ services:
       context: ..
     depends_on:
       - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
   irods-catalog-consumer:
     build:
       context: ..
     depends_on:
       - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:
 

--- a/projects/ubuntu-20.04/ubuntu-20.04-mysql-8.0/docker-compose.yml
+++ b/projects/ubuntu-20.04/ubuntu-20.04-mysql-8.0/docker-compose.yml
@@ -43,10 +43,19 @@ services:
       context: ..
     depends_on:
       - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
 
   irods-catalog-consumer:
     build:
       context: ..
     depends_on:
       - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:
 

--- a/projects/ubuntu-20.04/ubuntu-20.04-postgres-10.12/docker-compose.yml
+++ b/projects/ubuntu-20.04/ubuntu-20.04-postgres-10.12/docker-compose.yml
@@ -11,9 +11,18 @@ services:
             context: ..
         depends_on:
             - catalog
+        volumes:
+            - shared_volume:/irods_testing_environment_mount_dir
 
     irods-catalog-consumer:
         build:
             context: ..
         depends_on:
             - irods-catalog-provider
+        volumes:
+            - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:


### PR DESCRIPTION
All of the OS's for postgres and mysql versions were testing.

I also removed the following at Alan's request:

- ubuntu-20.04 / mysql-5.7

The shared_volume change creates a volume called "shared_volume" and each container mounts this to /irods_testing_environment_mount_dir.