### PR TITLE
[#96] Use queue.Queue to manage test list

### DIFF
--- a/irods_testing_environment/logs.py
+++ b/irods_testing_environment/logs.py
@@ -20,7 +20,7 @@ def configure(verbosity=1, log_filename=None):
 
     logging.basicConfig(
         level = level if level > logging.NOTSET else logging.DEBUG,
-        format = '%(asctime)-15s %(levelname)s - %(message)s',
+        format = '%(asctime)-15s - %(message)s',
         handlers = handlers
     )
 

--- a/irods_testing_environment/test_manager.py
+++ b/irods_testing_environment/test_manager.py
@@ -119,12 +119,12 @@ class test_manager:
                     f.result()
 
                     if tr.rc is 0 and len(tr.failed_tests()) is 0:
-                        logging.error('tests completed successfully [{}]'.format(tr.name()))
+                        logging.error(f'[{tr.name()}]: tests completed successfully')
                     else:
-                        logging.error('some tests failed [{}]'.format(tr.name()))
+                        logging.error(f'[{tr.name()}]: some tests failed')
 
                 except Exception as e:
-                    logging.error('[{}]: exception raised while running test'.format(tr.name()))
+                    logging.error(f'[{tr.name()}]: exception raised while running test')
                     logging.error(e)
 
                     tr.rc = 1

--- a/irods_testing_environment/test_runner.py
+++ b/irods_testing_environment/test_runner.py
@@ -129,6 +129,8 @@ class test_runner:
                 t = test_queue.get(block=False)
                 self.add_test(t)
 
+                logging.warning(f'[{self.name()}]: running test [{t}]')
+
                 start = time.time()
 
                 cmd, ec = self.execute_test(t, **kwargs)
@@ -139,17 +141,19 @@ class test_runner:
 
                 duration = end - start
 
+                logging.info(f'[{self.name()}]: cmd [{ec}] [{cmd}]')
+
                 if ec is 0:
                     self.passed_tests().append((t, duration))
-                    logging.error('[{}]: cmd succeeded [{}]'.format(self.name(), cmd))
+                    logging.error(f'[{self.name()}]: test passed [[{duration:>9.4f}]s] [{t or "all tests"}]')
 
                 else:
                     self.rc = ec
                     self.failed_tests().append((t, duration))
-                    logging.error('[{}]: cmd failed [{}] [{}]'.format(self.name(), ec, cmd))
+                    logging.error(f'[{self.name()}]: test failed [[{duration:>9.4f}]s] [{t or "all tests"}]')
 
                     if fail_fast:
-                        raise RuntimeError('[{}]: command failed [{}]'.format(self.name(), cmd))
+                        raise RuntimeError(f'[{self.name()}]: command failed [{cmd}]')
 
         except queue.Empty:
             logging.info(f'[{self.name()}]: Queue is empty!')


### PR DESCRIPTION
irods_testing_environment.test_manager now uses queue.Queue to manage the test list. Instead of evenly dealing out tests at the start of a run to each test_runner, the test_manager now adds the test list to a Queue and passes the Queue to the test_runner.run. The test_runners get tests from the Queue and runs them until there are no more tests in the queue.