### PR TITLE
[#10] Add SSL support to federation setup

### DIFF
--- a/federate.py
+++ b/federate.py
@@ -13,6 +13,7 @@ from irods_testing_environment import irods_setup
 from irods_testing_environment import irods_config
 from irods_testing_environment import json_utils
 from irods_testing_environment import federate
+from irods_testing_environment import ssl_setup
 from irods_testing_environment.install import install
 
 if __name__ == "__main__":
@@ -52,6 +53,12 @@ if __name__ == "__main__":
     parser.add_argument('--skip-setup',
                         action='store_false', dest='do_setup',
                         help='If indicated, the Zones will not be set up, only federated.')
+
+    parser.add_argument('--use-ssl',
+                        dest='use_ssl', action='store_true',
+                        help=textwrap.dedent('''\
+                            Indicates that SSL should be configured and enabled in each Zone.\
+                            '''))
 
     args = parser.parse_args()
 
@@ -93,6 +100,9 @@ if __name__ == "__main__":
             package_version=args.package_version)
 
         irods_setup.setup_irods_zones(ctx, zone_info_list, odbc_driver=args.odbc_driver)
+
+        if args.use_ssl:
+            ssl_setup.configure_ssl_in_zone(ctx.docker_client, ctx.compose_project)
 
     else:
         zone_info_list = irods_setup.get_info_for_zones(ctx, zone_names, args.consumers_per_zone)


### PR DESCRIPTION
Turns out, `configure_ssl_in_zone` will do just that. We should probably introduce more precision controls around that, but this at least gives us the option to enable SSL in the federated environments