### PR TITLE
Print iRODS sha/version and move database service check

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,5 +1,4 @@
 # grown-up modules
-import logging
 import textwrap
 
 # local modules
@@ -158,3 +157,18 @@ def add_common_args(parser):
                             Increase the level of output to stdout. \
                             CRITICAL and ERROR messages will always be printed. \
                             Add more to see more log messages (e.g. -vvv displays DEBUG).'''))
+
+
+def log_irods_version_and_commit_id(container):
+    '''Prints the version and commit_id found in the JSON version file.
+
+    Arguments:
+    container -- Container which has the version file
+    '''
+    import logging
+    from irods_testing_environment import irods_config
+
+    version = ".".join([str(i) for i in irods_config.get_irods_version(container)])
+    sha = irods_config.get_irods_commit_id(container)
+    logging.error(f'version:[{version}]')
+    logging.error(f'sha:[{sha}]')

--- a/run_core_tests.py
+++ b/run_core_tests.py
@@ -69,6 +69,8 @@ if __name__ == "__main__":
 
     rc = 0
 
+    containers = None
+
     try:
         if args.do_setup:
             # Bring up the services
@@ -113,6 +115,10 @@ if __name__ == "__main__":
         raise
 
     finally:
+        if containers:
+            # Just grab the version and sha from the first container since they are all running the same thing.
+            cli.log_irods_version_and_commit_id(containers[0])
+
         if args.save_logs:
             try:
                 logging.error('collecting logs [{}]'.format(output_directory))

--- a/run_federation_tests.py
+++ b/run_federation_tests.py
@@ -71,8 +71,7 @@ if __name__ == "__main__":
     logs.configure(args.verbosity, os.path.join(output_directory, 'script_output.log'))
 
     rc = 0
-    last_command_to_fail = None
-    containers = list()
+    container = None
 
     try:
         if args.do_setup:
@@ -154,6 +153,10 @@ if __name__ == "__main__":
         raise
 
     finally:
+        if container:
+            # Just grab the version and sha from the test container since it is what is being tested.
+            cli.log_irods_version_and_commit_id(container)
+
         if args.save_logs:
             try:
                 logging.error('collecting logs [{}]'.format(output_directory))

--- a/run_topology_tests.py
+++ b/run_topology_tests.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     logs.configure(args.verbosity, os.path.join(output_directory, 'script_output.log'))
 
     rc = 0
-    last_command_to_fail = None
+    container = None
 
     try:
         if args.do_setup:
@@ -142,6 +142,10 @@ if __name__ == "__main__":
         raise
 
     finally:
+        if container:
+            # Just grab the version and sha from the test container since it is what is being tested.
+            cli.log_irods_version_and_commit_id(container)
+
         if args.save_logs:
             try:
                 logging.error('collecting logs [{}]'.format(output_directory))

--- a/run_unit_tests.py
+++ b/run_unit_tests.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
     logs.configure(args.verbosity, os.path.join(output_directory, 'script_output.log'))
 
     rc = 0
+    containers = None
 
     try:
         if args.do_setup:
@@ -98,6 +99,10 @@ if __name__ == "__main__":
         raise
 
     finally:
+        if containers:
+            # Just grab the version and sha from the first container since they are all running the same thing.
+            cli.log_irods_version_and_commit_id(containers[0])
+
         if args.save_logs:
             logging.warning('collecting logs [{}]'.format(output_directory))
 


### PR DESCRIPTION
Addresses #143 
Addresses #144 

Decided that just printing sha after the whole test run is probably best for now (rather than for each executor). If the need arises in the future, we can do something like that.