### PR TITLE
[#154] Adjusted charset and collation settings for 4.2 and MySQL 8

### DIFF
--- a/projects/ubuntu-18.04/ubuntu-18.04-mysql-8.0/docker-compose.yml
+++ b/projects/ubuntu-18.04/ubuntu-18.04-mysql-8.0/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         #    (you *might* want to use the less safe log_bin_trust_function_creators
         #    variable)
         #
-        command: "--transaction-isolation=READ-COMMITTED --collation-server=utf8mb4_0900_as_cs --disable-log-bin"
+        command: "--transaction-isolation=READ-COMMITTED --character-set-server=latin1 --collation-server=latin1_general_cs --disable-log-bin"
 
         # The default docker security profile restricts several things to protect the OS. This results
         # in the MySQL container logging the following on each interaction:


### PR DESCRIPTION
Running unit tests and core tests for tip of 4-2-stable to verify everything is copacetic.

As of this time, tip of 4-2-stable is https://github.com/irods/irods/commit/43b20bae084e68c837b5e74440205a93abdfdfb2.