### PR TITLE
[_156] Allow ubuntu18.04 images to build

### DIFF
--- a/projects/ubuntu-18.04/Dockerfile
+++ b/projects/ubuntu-18.04/Dockerfile
@@ -20,6 +20,8 @@ RUN wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-k
 RUN apt-get update && \
     apt-get install -y \
         libcurl4-gnutls-dev \
+        libxml2 \
+        libxslt1-dev \
         python-distro \
         python-jsonschema \
         python-pip \

--- a/projects/ubuntu-18.04/Dockerfile
+++ b/projects/ubuntu-18.04/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting && \
+RUN python3 -m pip install unittest-xml-reporting==3.1.0 && \
     python2 -m pip install xmlrunner
 
 RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir

--- a/projects/ubuntu-18.04/Dockerfile
+++ b/projects/ubuntu-18.04/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting==3.1.0 && \
+RUN python3 -m pip install 'unittest-xml-reporting<3.1.0' && \
     python2 -m pip install xmlrunner
 
 RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir

--- a/projects/ubuntu-18.04/Dockerfile
+++ b/projects/ubuntu-18.04/Dockerfile
@@ -20,8 +20,6 @@ RUN wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-k
 RUN apt-get update && \
     apt-get install -y \
         libcurl4-gnutls-dev \
-        libxml2 \
-        libxslt1-dev \
         python-distro \
         python-jsonschema \
         python-pip \


### PR DESCRIPTION
Apparently the Python module `unittest-xml-reporting` grew a couple of OS package dependencies in a minor OS update - which we'd notice rebuilding the base image for the ubuntu-18.04 platform This installs those packages in the Docker file for that platform.