### PR TITLE
Add parallel topology tests and pin unittest-xml-reporting version

### DIFF
--- a/irods_testing_environment/context.py
+++ b/irods_testing_environment/context.py
@@ -329,7 +329,7 @@ def is_irods_server_in_local_zone(container, local_zone):
     raise NotImplementedError('service name is not supported [{}]'.format(container.name))
 
 
-def topology_hostnames(docker_client, compose_project):
+def project_hostnames(docker_client, compose_project):
     """Return a map of container names to hostnames for the provided Compose project as a dict.
 
     Arguments:

--- a/irods_testing_environment/irods_setup.py
+++ b/irods_testing_environment/irods_setup.py
@@ -45,15 +45,50 @@ class zone_info(object):
         self.provider_service_instance = provider_service_instance
         self.consumer_service_instances = consumer_service_instances
 
+
+    def provider_container(self, ctx):
+        """Return Docker Container running the iRODS CSP."""
+        return ctx.docker_client.containers.get(
+            context.irods_catalog_provider_container(
+                ctx.compose_project.name,
+                service_instance=self.provider_service_instance)
+        )
+
+
+    def consumer_container(self, ctx, instance):
+        """Return Docker Container running an iRODS CSC with specified instance."""
+        return ctx.docker_client.containers.get(
+            context.irods_catalog_consumer_container(
+                ctx.compose_project.name,
+                service_instance=instance)
+        )
+
+
+    def consumer_containers(self, ctx):
+        """Return list of Docker Containers running the iRODS CSCs."""
+        return [self.consumer_container(ctx, i) for i in self.consumer_service_instances]
+
+
     def provider_hostname(self, ctx):
         """Return hostname for the container running the iRODS CSP."""
+        return context.container_hostname(self.provider_container(ctx))
+
+
+    def consumer_hostname(self, ctx, instance):
+        """Return hostname for the container running an iRODS CSC with specified instance."""
         return context.container_hostname(
             ctx.docker_client.containers.get(
                 context.irods_catalog_provider_container(
                     ctx.compose_project.name,
-                    service_instance=self.provider_service_instance)
+                    service_instance=instance)
             )
         )
+
+
+    def consumer_hostnames(self, ctx):
+        """Return list of hostnames for the containers running the iRODS CSCs."""
+        return [self.consumer_hostname(ctx, i) for i in self.consumer_service_instances]
+
 
 class setup_input_builder(object):
     """Builder for iRODS setup script inputs.

--- a/irods_testing_environment/test_runner.py
+++ b/irods_testing_environment/test_runner.py
@@ -166,7 +166,7 @@ class test_runner:
             logging.error('[{}]: tests that failed [{}]'.format(self.name(), self.failed_tests()))
 
 
-    def execute_test(self, test, **kwargs):
+    def execute_test(self, test, options=None, **kwargs):
         """Execute `test` with return the command run and the return code."""
         raise NotImplementedError('test_runner is a base class and should not be used directly')
 
@@ -210,7 +210,7 @@ class test_runner_irods_unit_tests(test_runner):
         super(test_runner_irods_unit_tests, self).__init__(executing_container)
 
 
-    def execute_test(self, test, reporter='junit'):
+    def execute_test(self, test, options=None, reporter='junit'):
         """Execute `test` and return the command run and the return code.
 
         If `test` is `None`, a `TypeError` is raised because the test runner requires that a
@@ -218,6 +218,7 @@ class test_runner_irods_unit_tests(test_runner):
 
         Arguments:
         test -- name of the test to execute
+        options -- list of strings which will be appended to the command to execute
         reporter -- Catch2 reporter to use (options: console, compact, junit, xml)
         """
         if test is None:
@@ -227,9 +228,8 @@ class test_runner_irods_unit_tests(test_runner):
         output_dir = os.path.join(context.irods_home(), 'log')
         output_path = os.path.join(output_dir, f'{test}_{reporter}_report.{extension}')
 
-        cmd = [os.path.join(context.unit_tests(), test),
-               '--reporter', reporter,
-               '--out', output_path]
+        cmd = [os.path.join(context.unit_tests(), test)] + (options or ['--reporter', reporter, '--out', output_path])
+
         return cmd, execute.execute_command(self.executor,
                                             ' '.join(cmd),
                                             user='irods',
@@ -275,10 +275,10 @@ class test_runner_irods_plugin_tests(test_runner):
 
     def execute_test(self,
                      test,
+                     options=None,
                      plugin_repo_name=None,
                      plugin_branch=None,
-                     path_to_test_hook_on_host=None,
-                     options=None):
+                     path_to_test_hook_on_host=None):
         """Execute `test` and return the command run and the return code.
 
         If `test` is `None`, the test hook will be run without any options. This is an
@@ -288,10 +288,10 @@ class test_runner_irods_plugin_tests(test_runner):
 
         Arguments:
         test -- name of the test to execute
+        options -- list of strings which will be appended to the command to execute
         plugin_repo_name -- name of the git repo hosting the plugin test hook
         plugin_branch -- name of the branch of the git repo for desired test hook
         path_to_test_hook_on_host -- path to test hook file on the host
-        options -- list of strings which will be appended to the command to execute
         """
         from . import container_info
 

--- a/irods_testing_environment/test_utils.py
+++ b/irods_testing_environment/test_utils.py
@@ -106,7 +106,7 @@ def run_specific_tests(containers, test_list=None, options=None, fail_fast=True)
     Arguments:
     containers -- target containers on which the tests will run
     test_list -- a list of strings of the tests to be run
-    options -- list of strings representing script options to pass to the run_tests.py script
+    options -- A list of lists of strings representing options to pass to the scripts running tests
     fail_fast -- if True, stop running after first failure; else, runs all tests
     """
     tests = test_list or get_test_list(containers[0])

--- a/projects/centos-7/Dockerfile
+++ b/projects/centos-7/Dockerfile
@@ -43,7 +43,13 @@ RUN yum update -y && \
     yum clean all && \
     rm -rf /var/cache/yum /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting distro psutil pyodbc jsonschema requests
+RUN python3 -m pip install \
+    distro \
+    jsonschema \
+    psutil \
+    pyodbc \
+    requests \
+    'unittest-xml-reporting<3.1.0'
 
 COPY rsyslog.conf /etc/rsyslog.conf
 

--- a/projects/centos-7/release.Dockerfile
+++ b/projects/centos-7/release.Dockerfile
@@ -43,7 +43,13 @@ RUN yum update -y && \
     yum clean all && \
     rm -rf /var/cache/yum /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting distro psutil pyodbc jsonschema requests
+RUN python3 -m pip install \
+    distro \
+    jsonschema \
+    psutil \
+    pyodbc \
+    requests \
+    'unittest-xml-reporting<3.1.0'
 
 COPY rsyslog.conf /etc/rsyslog.conf
 

--- a/projects/debian-11/Dockerfile
+++ b/projects/debian-11/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting
+RUN python3 -m pip install 'unittest-xml-reporting<3.1.0'
 
 RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir
 

--- a/projects/debian-11/release.Dockerfile
+++ b/projects/debian-11/release.Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting
+RUN python3 -m pip install 'unittest-xml-reporting<3.1.0'
 
 RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir
 

--- a/projects/rockylinux-8/Dockerfile
+++ b/projects/rockylinux-8/Dockerfile
@@ -44,7 +44,13 @@ RUN yum update -y && \
     yum clean all && \
     rm -rf /var/cache/yum /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting distro psutil pyodbc jsonschema requests
+RUN python3 -m pip install \
+    distro \
+    jsonschema \
+    psutil \
+    pyodbc \
+    requests \
+    'unittest-xml-reporting<3.1.0'
 
 COPY rsyslog.conf /etc/rsyslog.conf
 

--- a/projects/rockylinux-8/release.Dockerfile
+++ b/projects/rockylinux-8/release.Dockerfile
@@ -44,7 +44,13 @@ RUN yum update -y && \
     yum clean all && \
     rm -rf /var/cache/yum /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting distro psutil pyodbc jsonschema requests
+RUN python3 -m pip install \
+    distro \
+    jsonschema \
+    psutil \
+    pyodbc \
+    requests \
+    'unittest-xml-reporting<3.1.0'
 
 COPY rsyslog.conf /etc/rsyslog.conf
 

--- a/projects/ubuntu-18.04/Dockerfile
+++ b/projects/ubuntu-18.04/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting && \
+RUN python3 -m pip install 'unittest-xml-reporting<3.1.0' && \
     python2 -m pip install xmlrunner
 
 RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir

--- a/projects/ubuntu-18.04/release.Dockerfile
+++ b/projects/ubuntu-18.04/release.Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting && \
+RUN python3 -m pip install 'unittest-xml-reporting<3.1.0' && \
     python2 -m pip install xmlrunner
 
 RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir

--- a/projects/ubuntu-20.04/Dockerfile
+++ b/projects/ubuntu-20.04/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting
+RUN python3 -m pip install 'unittest-xml-reporting<3.1.0'
 
 RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir
 

--- a/projects/ubuntu-20.04/release.Dockerfile
+++ b/projects/ubuntu-20.04/release.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN python3 -m pip install unittest-xml-reporting
+RUN python3 -m pip install 'unittest-xml-reporting<3.1.0'
 
 RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir
 

--- a/run_core_tests.py
+++ b/run_core_tests.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
             if args.do_setup:
                 ssl_setup.configure_ssl_in_zone(ctx.docker_client, ctx.compose_project)
 
-        rc = test_utils.run_specific_tests(containers, args.tests, options, args.fail_fast)
+        rc = test_utils.run_specific_tests(containers, args.tests, [options] * args.executor_count, args.fail_fast)
 
     except Exception as e:
         logging.critical(e)

--- a/run_federation_tests.py
+++ b/run_federation_tests.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
 
         version = irods_config.get_irods_version(remote_container)
         zone = irods_config.get_irods_zone_name(remote_container)
-        host = context.topology_hostnames(ctx.docker_client, ctx.compose_project)[
+        host = context.project_hostnames(ctx.docker_client, ctx.compose_project)[
                 context.irods_catalog_provider_container(ctx.compose_project.name)]
 
         options = ['--xml_output', '--federation', '.'.join(str(v) for v in version), zone, host]
@@ -144,7 +144,7 @@ if __name__ == "__main__":
 
         rc = test_utils.run_specific_tests([container],
                                            args.tests or ['test_federation'],
-                                           options,
+                                           [options] * args.executor_count,
                                            args.fail_fast)
 
     except Exception as e:


### PR DESCRIPTION
Addresses #52 
Addresses #156 
Supersedes #157

It seems to work, although topology tests fail pretty frequently when running with `--concurrent-test-executor-count 4` (I'm guessing because this spawns 20 containers). On the plus side, might be a good way to more reliably reproduce errors seen with sporadic test failures recently.

Still need to test with a plugin to make sure that hasn't gone sideways. Core tests, unit tests, and federation tests are working.