### PR TITLE
[#53] Fix running plugin tests in parallel

### DIFF
--- a/run_plugin_tests.py
+++ b/run_plugin_tests.py
@@ -112,7 +112,7 @@ try:
                                      args.plugin_name,
                                      args.test_hook,
                                      args.tests,
-                                     [options],
+                                     [options] * args.executor_count,
                                      args.fail_fast)
 
 except Exception as e:


### PR DESCRIPTION
In service of #53 

Apparently this interface changed at some point and was not reflected in the plugin test runner script.