### PR TITLE
Running the test environment with podman

### DIFF
--- a/irods_testing_environment/context.py
+++ b/irods_testing_environment/context.py
@@ -27,7 +27,7 @@ class context(object):
                     platform_service_name or irods_catalog_provider_service(),
                     platform_service_instance)))
 
-        return self.platform_image_tag
+        return self.platform_image_tag.split('/')[-1]
 
     def database(self, database_service_instance=1):
         """Return database Docker image from the database service in `self.compose_project`.
@@ -39,7 +39,7 @@ class context(object):
             self.database_image_tag = base_image(self.docker_client.containers.get(
                 irods_catalog_database_container(self.compose_project.name)))
 
-        return self.database_image_tag
+        return self.database_image_tag.split('/')[-1]
 
     def platform_name(self):
         """Return the repo name for the OS platform image for this Compose project."""

--- a/irods_testing_environment/context.py
+++ b/irods_testing_environment/context.py
@@ -193,7 +193,7 @@ def base_image(container, tag=0):
     """Return the base image for the specified docker.container.
 
     The base image is the last (read: oldest) item in the history() of a Docker image that has a
-    valid ID (read: not "<missing>").
+    valid ID (read: not "<missing>" or "sha256:<missing>").
 
     Arguments:
     container -- docker.container from which the OS platform is to be extracted
@@ -203,7 +203,7 @@ def base_image(container, tag=0):
                 container.client.images.get(
                     container.client.api.inspect_container(container.name)['Config']['Image']
                 ).history()
-            if image['Id'] != '<missing>'][-1]['Tags'][tag]
+            if '<missing>' not in image['Id']][-1]['Tags'][tag]
 
 
 def container_hostname(container):

--- a/irods_testing_environment/irods_setup.py
+++ b/irods_testing_environment/irods_setup.py
@@ -436,8 +436,17 @@ def setup_irods_server(container, setup_input):
     from . import container_info
     from . import irods_config
 
-    if stop_irods(container) != 0:
-        logging.debug(f'[{container.name}] failed to stop iRODS server before setup')
+    try:
+        if stop_irods(container) != 0:
+            logging.debug(f'[{container.name}] failed to stop iRODS server before setup')
+    except Exception as e:
+        error_msg = f'[{container.name}] failed to stop iRODS server before setup: {str(e)}'
+        if "unable to find user irods" in str(e):
+            # If the user didn't exist at this point then the service probably wasn't started.
+           logging.debug(error_msg)
+        else:
+           logging.error(error_msg)
+           raise e
 
     ec = execute.execute_command(container, 'bash -c \'echo "{}" > /input\''.format(setup_input))
     if ec != 0:


### PR DESCRIPTION
While trying to run the test environment with podman instead of docker I ran into some small issues.

Whether they are strictly caused by differences between "podman" and "docker" I don't know. The patches might be small improvements anyway.

I tested on Fedora 39. OS packages installed were "podman", "podman-compose" and "podman-docker". I created a symbolic link "docker-compose" in the PATH to "podman-compose".

The virtual environment was set-up with python3.6 (the default on Fedora 39 is python3.12) as this makes installing the venv run without errors. No specific changes were necessary.

I used the "rootless" set-up for podman.

```bash
# Source: https://unix.stackexchange.com/questions/731645/podman-w-docker-compose-run-as-user

# Disable system wide settings
$ systemctl disable --now podman podman.socket

# Enable user wide settings
$ systemctl enable --now --user podman podman.socket
$ systemctl --user start podman podman.socket

# Make `docker` use it:
$ Check what path is used for the unix socket:
$ podman info --format '{{.Host.RemoteSocket.Path}}'

$ export DOCKER_HOST=unix:///run/user/1000/podman/podman.sock

# Debug ouput:
$ podman --log-level=debug system service -t0
# Check connectivity:
$ curl --unix-socket /run/user/1000/podman/podman.sock -X GET http://d/version`[d]`
```

Using the xunit-viewer container also works, if you remember to use the ":Z" flag (SELinux is used on RHEL like systems) for the /results bind-mount.