### PR TITLE
[#203] Ensure all required packages can be found

### DIFF
--- a/projects/rockylinux-9/Dockerfile
+++ b/projects/rockylinux-9/Dockerfile
@@ -9,11 +9,13 @@ RUN dnf update -y || [ "$?" -eq 100 ] && \
     rm -rf /tmp/*
 
 RUN dnf install -y \
+        dnf-plugins-core \
         ca-certificates \
         epel-release \
         gnupg \
         wget \
     && \
+    dnf config-manager --set-enabled crb && \
     rm -rf /tmp/*
 
 RUN dnf install -y \


### PR DESCRIPTION
Fix rockylinux-9 package install issues.

It should be all spaces now.