### PR TITLE
[#217] Add centos 7 / mariadb 10.6 project

### DIFF
--- a/irods_testing_environment/odbc_setup.py
+++ b/irods_testing_environment/odbc_setup.py
@@ -757,6 +757,18 @@ def configure_odbc_driver_rockylinux_9_mariadb_114(csp_container, odbc_driver):
     """
     configure_odbc_driver_el_9_mariadb(csp_container, odbc_driver)
 
+def configure_odbc_driver_centos_7_mariadb_106(csp_container, odbc_driver):
+    """Configure ODBC driver for mariadb 10.6 centos 7.
+
+    Argument:
+    csp_container -- docker container on which the iRODS catalog service provider is running
+    odbc_driver -- path to local archive file containing the ODBC driver package
+    """
+    # This function assumes that irods/irods#7323 will not be resolved before the removal of all centos 7 projects.
+    # Therefore, we will hard-code usage of the mysql 8.0 ODBC driver for the mariadb 10.6 project until this is
+    # removed on resolution of #217.
+    configure_odbc_driver_centos_7_mysql_80(csp_container, odbc_driver)
+
 def configure_odbc_driver(platform_image, database_image, csp_container, odbc_driver=None):
     """Make an ODBC setup strategy for the given database type.
 

--- a/projects/centos-7/centos-7-mariadb-10.6/docker-compose.yml
+++ b/projects/centos-7/centos-7-mariadb-10.6/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+
+services:
+  catalog:
+    image: mariadb:10.6
+    environment:
+      - MARIADB_ROOT_PASSWORD=testpassword
+      - MARIADB_USER=irods
+      - MARIADB_PASSWORD=testpassword
+    # For parity with mysql 8.0, we use utf8mb4 charset and utf8mb4_bin collation (for case sensitivity), and disable the binary log
+    command: "--transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --disable-log-bin"
+
+  irods-catalog-provider:
+    build:
+      context: ..
+      dockerfile: ${dockerfile}
+    depends_on:
+      - catalog
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
+
+  irods-catalog-consumer:
+    build:
+      context: ..
+      dockerfile: ${dockerfile}
+    depends_on:
+      - irods-catalog-provider
+    volumes:
+      - shared_volume:/irods_testing_environment_mount_dir
+
+# This volume is mounted on all test servers for detached mode testing which
+# requires a common vault.
+volumes:
+    shared_volume:


### PR DESCRIPTION
Linked to #217 because all Centos 7 projects will be removed in the near future.