### PR TITLE
[irods/irods#7957] Test config: Install python-irodsclient

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "compose"]
+	path = compose
+	url = https://github.com/docker/compose

--- a/README.md
+++ b/README.md
@@ -38,24 +38,13 @@ Compare the output to `requirements.txt`.
 
 `docker-compose` is being phased out by Docker and you may experience problems installing it via `pip`.
 
-If this happens to you, try doing the following:
+If this happens to you, use the submodule included with this repository.
 
-Clone the Docker Compose Git repository:
+Make sure the submodules are up to date and install the repo as a pip package:
 ```bash
-git clone https://github.com/docker/compose
-```
-
-Check out the latest tag which was still using the Python implementation:
-```bash
-cd compose
-git checkout 1.29.2
-```
-
-At this point, you can make the modifications needed to fix any problems you may encounter.
-
-Once done, back out and pip install the local directory:
-```bash
-cd -
+git submodule init
+# If you've already done this, make sure it's updated:
+git submodule update
 pip install ./compose
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If this happens to you, use the submodule included with this repository.
 Make sure the submodules are up to date and install the repo as a pip package:
 ```bash
 git submodule init
-# If you've already done this, make sure it's updated:
+# If you've already run 'git submodule init', make sure the submodule is up-to-date:
 git submodule update
 pip install ./compose
 ```


### PR DESCRIPTION
As a workaround for #8 
In service of irods/irods#7957

This is required to run one of the test suites for metadata_guard. As a plugin, it was able to avoid this by installing PRC in its test hook.