### PR TITLE
[#279] Allow pip to modify system packages for Debian 13

### DIFF
--- a/projects/debian-13/Dockerfile
+++ b/projects/debian-13/Dockerfile
@@ -56,6 +56,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
+# Given this is for testing purposes, we remove the file which blocks pip from
+# touching system packages. See https://peps.python.org/pep-0668/ for details.
+RUN rm /usr/lib/python3.*/EXTERNALLY-MANAGED
+
 RUN mkdir -p /irods_testing_environment_mount_dir && chmod 777 /irods_testing_environment_mount_dir
 
 ENTRYPOINT ["bash", "-c", "until false; do sleep 2147483647d; done"]


### PR DESCRIPTION
Companion PR: https://github.com/irods/irods_resource_plugin_s3/pull/2269

This is the pattern used in other Dockerfiles within this repo.

This change is needed so that plugin test hooks can setup the environment - e.g. S3 resource plugin. The testing environment also needs this for the python ci utilities script.

S3 resource plugin tests pass with this PR.