### PR TITLE
[#284] Fix getting base image tag

### DIFF
--- a/projects/almalinux-10/Dockerfile
+++ b/projects/almalinux-10/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM almalinux:10
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=almalinux:10
+
 SHELL [ "/usr/bin/bash", "-c" ]
 
 # Make sure we're starting with an up-to-date image

--- a/projects/almalinux-10/release.Dockerfile
+++ b/projects/almalinux-10/release.Dockerfile
@@ -2,6 +2,9 @@
 
 FROM almalinux:10
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=almalinux:10
+
 SHELL [ "/usr/bin/bash", "-c" ]
 
 # Make sure we're starting with an up-to-date image

--- a/projects/almalinux-8/Dockerfile
+++ b/projects/almalinux-8/Dockerfile
@@ -1,5 +1,8 @@
 FROM almalinux:8
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=almalinux:8
+
 RUN yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
     yum install -y \
         ca-certificates \

--- a/projects/almalinux-8/release.Dockerfile
+++ b/projects/almalinux-8/release.Dockerfile
@@ -1,5 +1,8 @@
 FROM almalinux:8
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=almalinux:8
+
 RUN yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
     yum install -y \
         ca-certificates \

--- a/projects/almalinux-9/Dockerfile
+++ b/projects/almalinux-9/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM almalinux:9
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=almalinux:9
+
 SHELL [ "/usr/bin/bash", "-c" ]
 
 # Make sure we're starting with an up-to-date image

--- a/projects/almalinux-9/release.Dockerfile
+++ b/projects/almalinux-9/release.Dockerfile
@@ -2,6 +2,9 @@
 
 FROM almalinux:9
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=almalinux:9
+
 SHELL [ "/usr/bin/bash", "-c" ]
 
 # Make sure we're starting with an up-to-date image

--- a/projects/debian-11/Dockerfile
+++ b/projects/debian-11/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:11
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=debian:11
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/projects/debian-11/release.Dockerfile
+++ b/projects/debian-11/release.Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:11
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=debian:11
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/projects/debian-12/Dockerfile
+++ b/projects/debian-12/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:12
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=debian:12
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/projects/debian-12/release.Dockerfile
+++ b/projects/debian-12/release.Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:12
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=debian:12
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/projects/debian-13/Dockerfile
+++ b/projects/debian-13/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:13
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=debian:13
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/projects/debian-13/release.Dockerfile
+++ b/projects/debian-13/release.Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:13
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=debian:13
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/projects/rockylinux-10/Dockerfile
+++ b/projects/rockylinux-10/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM rockylinux/rockylinux:10
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=rockylinux/rockylinux:10
+
 SHELL [ "/usr/bin/bash", "-c" ]
 
 # Make sure we're starting with an up-to-date image

--- a/projects/rockylinux-10/release.Dockerfile
+++ b/projects/rockylinux-10/release.Dockerfile
@@ -2,6 +2,9 @@
 
 FROM rockylinux/rockylinux:10
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=rockylinux/rockylinux:10
+
 SHELL [ "/usr/bin/bash", "-c" ]
 
 # Make sure we're starting with an up-to-date image

--- a/projects/rockylinux-8/Dockerfile
+++ b/projects/rockylinux-8/Dockerfile
@@ -1,5 +1,8 @@
 FROM rockylinux/rockylinux:8
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=rockylinux/rockylinux:8
+
 RUN yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
     yum install -y \
         ca-certificates \

--- a/projects/rockylinux-8/release.Dockerfile
+++ b/projects/rockylinux-8/release.Dockerfile
@@ -1,5 +1,8 @@
 FROM rockylinux/rockylinux:8
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=rockylinux/rockylinux:8
+
 RUN yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
     yum install -y \
         ca-certificates \

--- a/projects/rockylinux-9/Dockerfile
+++ b/projects/rockylinux-9/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM rockylinux/rockylinux:9
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=rockylinux/rockylinux:9
+
 SHELL [ "/usr/bin/bash", "-c" ]
 
 # Make sure we're starting with an up-to-date image

--- a/projects/rockylinux-9/release.Dockerfile
+++ b/projects/rockylinux-9/release.Dockerfile
@@ -2,6 +2,9 @@
 
 FROM rockylinux/rockylinux:9
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=rockylinux/rockylinux:9
+
 SHELL [ "/usr/bin/bash", "-c" ]
 
 # Make sure we're starting with an up-to-date image

--- a/projects/ubuntu-20.04/Dockerfile
+++ b/projects/ubuntu-20.04/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:20.04
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=ubuntu:20.04
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/projects/ubuntu-20.04/release.Dockerfile
+++ b/projects/ubuntu-20.04/release.Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:20.04
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=ubuntu:20.04
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/projects/ubuntu-22.04/Dockerfile
+++ b/projects/ubuntu-22.04/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:22.04
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=ubuntu:22.04
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/projects/ubuntu-24.04/Dockerfile
+++ b/projects/ubuntu-24.04/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:24.04
 
+# BASE_IMAGE_TAG must always match the image name for this build stage (the argument to the FROM instruction above).
+ENV BASE_IMAGE_TAG=ubuntu:24.04
+
 SHELL [ "/bin/bash", "-c" ]
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Addresses #284

This is option 3 described in https://github.com/irods/irods_testing_environment/issues/284#issuecomment-3843452779

This time... I'm just going to try all of them. And hopefully not fill up my disk.

- [x] ubuntu:20.04
- [x] ubuntu:22.04
- [x] ubuntu:24.04
- [x] debian:11
- [x] debian:12
- [x] debian:13
- [x] rockylinux/rockylinux:8
- [x] rockylinux/rockylinux:9
- [ ] rockylinux/rockylinux:10
- [x] almalinux:8
- [x] almalinux:9
- [ ] almalinux:10